### PR TITLE
feat(cli): add --connected filter for runline actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 ```bash
 # List all available actions
 runline actions
+# List actions only for connected services
+runline actions --connected
 
 # Get Nike's brand colors
 runline exec 'return await brandfetch.brand.getColors({ domain: "nike.com" })'
@@ -360,6 +362,7 @@ Every command supports `--json`. Use `runline actions --json` for full schemas w
 
 ```bash
 runline actions --json          # all actions with schemas
+runline actions --connected --json  # only connected services
 runline exec '<code>' --json    # structured { result, logs } output
 ```
 
@@ -388,6 +391,7 @@ console.log(result.result);  // [{ hex: "#635BFF", type: "accent", brightness: 1
 runline exec "<code>"                  # execute JS in sandbox
 runline exec -f ./script.js            # execute a file
 runline actions                        # list all actions
+runline actions --connected            # only actions for configured connections
 runline plugin install <source>        # install from git/npm/local
 runline plugin list                    # list installed plugins
 runline plugin remove <name>           # remove a plugin

--- a/packages/runline/src/commands/actions.ts
+++ b/packages/runline/src/commands/actions.ts
@@ -1,15 +1,25 @@
 import chalk from "chalk";
+import { loadConfig } from "../config/loader.js";
 import { loadAllPlugins } from "../plugin/loader.js";
 import { registry } from "../plugin/registry.js";
 import { printJson } from "../utils/output.js";
 
-export async function actions(options: { json?: boolean }): Promise<void> {
+export async function actions(options: {
+  json?: boolean;
+  connected?: boolean;
+}): Promise<void> {
   await loadAllPlugins();
   const all = registry.getAllActions();
+  const connectedPlugins = options.connected
+    ? new Set(loadConfig().connections.map((c) => c.plugin))
+    : null;
+  const filtered = connectedPlugins
+    ? all.filter(({ plugin }) => connectedPlugins.has(plugin))
+    : all;
 
   if (options.json) {
     printJson(
-      all.map(({ plugin, action }) => ({
+      filtered.map(({ plugin, action }) => ({
         plugin,
         action: action.name,
         description: action.description,
@@ -19,13 +29,20 @@ export async function actions(options: { json?: boolean }): Promise<void> {
     return;
   }
 
-  if (all.length === 0) {
-    console.log("No actions registered. Install a plugin first.");
+  if (filtered.length === 0) {
+    if (options.connected) {
+      console.log("No actions found for connected services.");
+      console.log(
+        "Add a connection first: runline connection add <name> -p <plugin>",
+      );
+    } else {
+      console.log("No actions registered. Install a plugin first.");
+    }
     return;
   }
 
-  const grouped = new Map<string, typeof all>();
-  for (const entry of all) {
+  const grouped = new Map<string, typeof filtered>();
+  for (const entry of filtered) {
     const list = grouped.get(entry.plugin) ?? [];
     list.push(entry);
     grouped.set(entry.plugin, list);

--- a/packages/runline/src/main.ts
+++ b/packages/runline/src/main.ts
@@ -73,9 +73,13 @@ Examples:
 program
   .command("actions")
   .description("List all available actions and their schemas")
-  .action(async (_opts, cmd) => {
+  .option(
+    "-c, --connected",
+    "Only show actions for plugins with configured connections",
+  )
+  .action(async (opts, cmd) => {
     const globals = cmd.optsWithGlobals();
-    await actions({ json: globals.json });
+    await actions({ json: globals.json, connected: opts.connected });
   });
 
 // ── connection ──────────────────────────────────────────


### PR DESCRIPTION
Summary
- add --connected option to runline actions
- filter listed actions to plugins present in .runline/config.json connections
- keep default runline actions behavior unchanged
- document new flag in README examples and CLI reference

Validation
- bun --filter runline test