### PR TITLE
fix(pi-runline): picker shows full bundled catalog, not connection-gated subset

### DIFF
--- a/packages/pi-runline/extensions/connection-setup.ts
+++ b/packages/pi-runline/extensions/connection-setup.ts
@@ -75,7 +75,9 @@ export async function promptForCredentials(
   runlineDir: string,
   plugins: PluginSummary[],
   newlyEnabled: string[],
+  options: { force?: boolean } = {},
 ): Promise<string[]> {
+  const force = options.force === true;
   const config = readConfig(runlineDir);
   const connections = getConnections(config);
   const saved: string[] = [];
@@ -87,16 +89,17 @@ export async function promptForCredentials(
     const schema = plugin.connectionConfigSchema;
     if (isSchemaEmpty(schema)) continue; // no creds needed
 
-    if (connectionFor(connections, name)) continue; // already configured
+    if (!force && connectionFor(connections, name)) continue; // already configured
 
     // Check env — if every required field has an env var set, skip the prompt.
+    // Skipped on `force` (the user explicitly asked to re-enter values).
     const requiredFields = Object.entries(schema!).filter(
       ([, f]) => f.required,
     );
     const allFromEnv = requiredFields.every(
       ([, f]) => f.env && process.env[f.env],
     );
-    if (requiredFields.length > 0 && allFromEnv) continue;
+    if (!force && requiredFields.length > 0 && allFromEnv) continue;
 
     const wantSetup = await ctx.ui.confirm(
       `Set up ${name}?`,
@@ -137,7 +140,12 @@ export async function promptForCredentials(
       plugin: name,
       config: values,
     };
-    connections.push(conn);
+    const existingIdx = connections.findIndex((c) => c.plugin === name);
+    if (existingIdx >= 0) {
+      connections[existingIdx] = conn;
+    } else {
+      connections.push(conn);
+    }
     saved.push(name);
   }
 

--- a/packages/pi-runline/extensions/plugin-picker.ts
+++ b/packages/pi-runline/extensions/plugin-picker.ts
@@ -28,7 +28,7 @@ export interface PluginPickerResult {
  * Keys:
  *   ↑ / ↓       — move highlight
  *   space       — toggle current item
- *   Ctrl-A      — toggle all (filtered view)
+ *   alt-r       — reconfigure highlighted plugin (when connected)
  *   enter       — save and close
  *   esc / C-c   — cancel
  *   type        — fuzzy filter

--- a/packages/pi-runline/extensions/plugin-picker.ts
+++ b/packages/pi-runline/extensions/plugin-picker.ts
@@ -5,11 +5,15 @@ import { fuzzyFilter, Input, visibleWidth } from "@mariozechner/pi-tui";
 export interface PluginPickerItem {
   name: string;
   actionCount: number;
+  /** Plugin already has a stored connection — eligible for Ctrl-R reconfigure. */
+  connected?: boolean;
 }
 
 export interface PluginPickerResult {
   /** undefined = cancelled */
   selected?: string[];
+  /** Set when the user pressed Ctrl-R on a connected plugin. */
+  reconfigure?: string;
 }
 
 /**
@@ -70,7 +74,7 @@ export class PluginPicker implements Component {
     body.push(
       theme.fg(
         "dim",
-        "type to filter · space toggle · ^A toggle all · enter save · esc cancel",
+        "type to filter · space toggle · ^A toggle all · ^R reconfigure · enter save · esc cancel",
       ),
     );
     body.push("");
@@ -106,9 +110,12 @@ export class PluginPicker implements Component {
         ? theme.fg("success", box)
         : theme.fg("dim", box);
       const name = isCur ? theme.bold(item.name) : item.name;
+      const connectedTag = item.connected
+        ? theme.fg("success", " • connected")
+        : "";
       const count = theme.fg("dim", `  ${item.actionCount} actions`);
       const arrow = isCur ? theme.fg("accent", "❯ ") : "  ";
-      body.push(`${arrow}${boxColored} ${name}${count}`);
+      body.push(`${arrow}${boxColored} ${name}${connectedTag}${count}`);
     }
     for (let i = end - start; i < this.maxRows; i++) body.push("");
 
@@ -174,6 +181,15 @@ export class PluginPicker implements Component {
       for (const i of this.filtered) {
         if (allSelected) this.selected.delete(i.name);
         else this.selected.add(i.name);
+      }
+      return;
+    }
+    if (data === "\x12") {
+      // Ctrl-R — reconfigure the highlighted plugin if it already has
+      // saved credentials. No-op otherwise.
+      const item = this.filtered[this.cursor];
+      if (item?.connected) {
+        this.onDone({ reconfigure: item.name });
       }
       return;
     }

--- a/packages/pi-runline/extensions/plugin-picker.ts
+++ b/packages/pi-runline/extensions/plugin-picker.ts
@@ -80,7 +80,7 @@ export class PluginPicker implements Component {
     body.push(
       theme.fg(
         "dim",
-        "type to filter · space toggle · ^A toggle all · alt+r reconfigure · enter save · esc cancel",
+        "type to filter · space toggle · alt+r reconfigure · enter save · esc cancel",
       ),
     );
     body.push("");
@@ -178,15 +178,6 @@ export class PluginPicker implements Component {
       if (item) {
         if (this.selected.has(item.name)) this.selected.delete(item.name);
         else this.selected.add(item.name);
-      }
-      return;
-    }
-    if (data === "\x01") {
-      // Ctrl-A — toggle all visible
-      const allSelected = this.filtered.every((i) => this.selected.has(i.name));
-      for (const i of this.filtered) {
-        if (allSelected) this.selected.delete(i.name);
-        else this.selected.add(i.name);
       }
       return;
     }

--- a/packages/pi-runline/extensions/plugin-picker.ts
+++ b/packages/pi-runline/extensions/plugin-picker.ts
@@ -1,6 +1,12 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI } from "@mariozechner/pi-tui";
-import { fuzzyFilter, Input, visibleWidth } from "@mariozechner/pi-tui";
+import {
+  fuzzyFilter,
+  Input,
+  Key,
+  matchesKey,
+  visibleWidth,
+} from "@mariozechner/pi-tui";
 
 export interface PluginPickerItem {
   name: string;
@@ -74,7 +80,7 @@ export class PluginPicker implements Component {
     body.push(
       theme.fg(
         "dim",
-        "type to filter · space toggle · ^A toggle all · ^R reconfigure · enter save · esc cancel",
+        "type to filter · space toggle · ^A toggle all · alt+r reconfigure · enter save · esc cancel",
       ),
     );
     body.push("");
@@ -184,9 +190,10 @@ export class PluginPicker implements Component {
       }
       return;
     }
-    if (data === "\x12") {
-      // Ctrl-R — reconfigure the highlighted plugin if it already has
-      // saved credentials. No-op otherwise.
+    if (matchesKey(data, Key.alt("r"))) {
+      // Alt-R — reconfigure the highlighted plugin if it already has
+      // saved credentials. No-op otherwise. (Ctrl-R is reserved by pi
+      // for `app.session.rename` and never reaches handleInput.)
       const item = this.filtered[this.cursor];
       if (item?.connected) {
         this.onDone({ reconfigure: item.name });

--- a/packages/pi-runline/extensions/runline-context/index.ts
+++ b/packages/pi-runline/extensions/runline-context/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Markdown, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { Runline } from "runline";
+import { discoverPlugins, Runline } from "runline";
 import { promptForCredentials } from "../connection-setup.js";
 import { createPluginPickerFactory } from "../plugin-picker.js";
 import {
@@ -228,18 +228,22 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      let rl: Runline;
+      // Load the full bundled catalog directly — `Runline.fromProject`
+      // gates builtins by `connections[].plugin`, which is the wrong
+      // surface for the picker (the picker is HOW you decide which
+      // plugins to enable in the first place).
+      let allPlugins: Awaited<ReturnType<typeof discoverPlugins>>;
       try {
-        rl = await getRunline(ctx.cwd);
+        allPlugins = await discoverPlugins(runlineDir);
       } catch (err) {
         ctx.ui.notify(
-          `runline failed to load: ${(err as Error).message}`,
+          `runline failed to load plugins: ${(err as Error).message}`,
           "error",
         );
         return;
       }
 
-      const items = rl.plugins().map((p) => ({
+      const items = allPlugins.map((p) => ({
         name: p.name,
         actionCount: p.actions.length,
       }));
@@ -270,7 +274,7 @@ export default function (pi: ExtensionAPI) {
         const saved = await promptForCredentials(
           ctx,
           runlineDir,
-          rl.plugins(),
+          allPlugins,
           newlyEnabled,
         );
         if (saved.length > 0) {

--- a/packages/pi-runline/extensions/runline-context/index.ts
+++ b/packages/pi-runline/extensions/runline-context/index.ts
@@ -284,72 +284,48 @@ export default function (pi: ExtensionAPI) {
           );
         }
       }
-    },
-  });
 
-  pi.registerCommand("runline-reconfigure", {
-    description:
-      "Re-enter credentials for an already-configured runline plugin",
-    handler: async (_args, ctx) => {
-      if (!ctx.hasUI) return;
+      // Offer to reconfigure credentials for plugins that were already
+      // enabled and already have a stored connection. Without this, there
+      // is no path through `/runline-plugins` to re-enter an expired or
+      // mistyped token.
+      const connected = getConnectedPluginNames(runlineDir);
+      const reconfigurable = result.selected.filter(
+        (n) =>
+          previous.has(n) &&
+          connected.has(n) &&
+          allPlugins.some(
+            (p) =>
+              p.name === n &&
+              p.connectionConfigSchema &&
+              Object.keys(p.connectionConfigSchema).length > 0,
+          ),
+      );
 
-      const runlineDir = findRunlineDir(ctx.cwd);
-      if (!runlineDir) {
-        ctx.ui.notify("no .runline/ directory — run `runline init`", "error");
-        return;
-      }
-
-      let allPlugins: Awaited<ReturnType<typeof discoverPlugins>>;
-      try {
-        allPlugins = await discoverPlugins(runlineDir);
-      } catch (err) {
-        ctx.ui.notify(
-          `runline failed to load plugins: ${(err as Error).message}`,
-          "error",
+      const toReconfigure: string[] = [];
+      for (const name of reconfigurable) {
+        const yes = await ctx.ui.confirm(
+          `Reconfigure ${name}?`,
+          `${name} already has saved credentials. Re-enter them?`,
         );
-        return;
+        if (yes) toReconfigure.push(name);
       }
 
-      // Only offer plugins that have a credential schema. The picker is
-      // not initially-selected; the user toggles the one(s) they want to
-      // re-enter creds for.
-      const candidates = allPlugins.filter(
-        (p) =>
-          p.connectionConfigSchema &&
-          Object.keys(p.connectionConfigSchema).length > 0,
-      );
-      if (candidates.length === 0) {
-        ctx.ui.notify("no plugins with credentials available", "info");
-        return;
+      if (toReconfigure.length > 0) {
+        const updated = await promptForCredentials(
+          ctx,
+          runlineDir,
+          allPlugins,
+          toReconfigure,
+          { force: true },
+        );
+        if (updated.length > 0) {
+          ctx.ui.notify(
+            `credentials updated for ${updated.length} plugin(s)`,
+            "info",
+          );
+        }
       }
-
-      const items = candidates.map((p) => ({
-        name: p.name,
-        actionCount: p.actions.length,
-      }));
-      const result = await ctx.ui.custom(createPluginPickerFactory(items, []), {
-        overlay: true,
-        overlayOptions: { width: "80%", maxHeight: "80%" },
-      });
-
-      if (!result.selected || result.selected.length === 0) {
-        ctx.ui.notify("reconfigure cancelled", "info");
-        return;
-      }
-
-      const saved = await promptForCredentials(
-        ctx,
-        runlineDir,
-        allPlugins,
-        result.selected,
-        { force: true },
-      );
-      ctx.ui.notify(
-        saved.length > 0
-          ? `credentials updated for ${saved.length} plugin(s)`
-          : "no credentials updated",
-        "info",
-      );
     },
   });
 }

--- a/packages/pi-runline/extensions/runline-context/index.ts
+++ b/packages/pi-runline/extensions/runline-context/index.ts
@@ -286,4 +286,70 @@ export default function (pi: ExtensionAPI) {
       }
     },
   });
+
+  pi.registerCommand("runline-reconfigure", {
+    description:
+      "Re-enter credentials for an already-configured runline plugin",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) return;
+
+      const runlineDir = findRunlineDir(ctx.cwd);
+      if (!runlineDir) {
+        ctx.ui.notify("no .runline/ directory — run `runline init`", "error");
+        return;
+      }
+
+      let allPlugins: Awaited<ReturnType<typeof discoverPlugins>>;
+      try {
+        allPlugins = await discoverPlugins(runlineDir);
+      } catch (err) {
+        ctx.ui.notify(
+          `runline failed to load plugins: ${(err as Error).message}`,
+          "error",
+        );
+        return;
+      }
+
+      // Only offer plugins that have a credential schema. The picker is
+      // not initially-selected; the user toggles the one(s) they want to
+      // re-enter creds for.
+      const candidates = allPlugins.filter(
+        (p) =>
+          p.connectionConfigSchema &&
+          Object.keys(p.connectionConfigSchema).length > 0,
+      );
+      if (candidates.length === 0) {
+        ctx.ui.notify("no plugins with credentials available", "info");
+        return;
+      }
+
+      const items = candidates.map((p) => ({
+        name: p.name,
+        actionCount: p.actions.length,
+      }));
+      const result = await ctx.ui.custom(createPluginPickerFactory(items, []), {
+        overlay: true,
+        overlayOptions: { width: "80%", maxHeight: "80%" },
+      });
+
+      if (!result.selected || result.selected.length === 0) {
+        ctx.ui.notify("reconfigure cancelled", "info");
+        return;
+      }
+
+      const saved = await promptForCredentials(
+        ctx,
+        runlineDir,
+        allPlugins,
+        result.selected,
+        { force: true },
+      );
+      ctx.ui.notify(
+        saved.length > 0
+          ? `credentials updated for ${saved.length} plugin(s)`
+          : "no credentials updated",
+        "info",
+      );
+    },
+  });
 }

--- a/packages/pi-runline/extensions/runline-context/index.ts
+++ b/packages/pi-runline/extensions/runline-context/index.ts
@@ -6,6 +6,7 @@ import { promptForCredentials } from "../connection-setup.js";
 import { createPluginPickerFactory } from "../plugin-picker.js";
 import {
   findRunlineDir,
+  getConnectedPluginNames,
   loadExtConfig,
   savePiPlugins,
 } from "../runline-resolve.js";

--- a/packages/pi-runline/extensions/runline-context/index.ts
+++ b/packages/pi-runline/extensions/runline-context/index.ts
@@ -303,13 +303,22 @@ export default function (pi: ExtensionAPI) {
           ),
       );
 
-      const toReconfigure: string[] = [];
-      for (const name of reconfigurable) {
-        const yes = await ctx.ui.confirm(
-          `Reconfigure ${name}?`,
-          `${name} already has saved credentials. Re-enter them?`,
+      let toReconfigure: string[] = [];
+      if (reconfigurable.length > 0) {
+        // Single multi-select picker so the user gets one screen instead of
+        // a chain of Y/N confirms.
+        const reconfigureItems = reconfigurable.map((name) => {
+          const p = allPlugins.find((pl) => pl.name === name);
+          return { name, actionCount: p?.actions.length ?? 0 };
+        });
+        const reconfigureResult = await ctx.ui.custom(
+          createPluginPickerFactory(reconfigureItems, []),
+          {
+            overlay: true,
+            overlayOptions: { width: "80%", maxHeight: "80%" },
+          },
         );
-        if (yes) toReconfigure.push(name);
+        toReconfigure = reconfigureResult.selected ?? [];
       }
 
       if (toReconfigure.length > 0) {

--- a/packages/pi-runline/extensions/runline-context/index.ts
+++ b/packages/pi-runline/extensions/runline-context/index.ts
@@ -244,9 +244,11 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
+      const connectedNames = getConnectedPluginNames(runlineDir);
       const items = allPlugins.map((p) => ({
         name: p.name,
         actionCount: p.actions.length,
+        connected: connectedNames.has(p.name),
       }));
       const { piPlugins } = loadExtConfig(runlineDir);
       const initial = piPlugins ?? [];
@@ -255,6 +257,27 @@ export default function (pi: ExtensionAPI) {
         createPluginPickerFactory(items, initial),
         { overlay: true, overlayOptions: { width: "80%", maxHeight: "80%" } },
       );
+
+      // Ctrl-R inside the picker — reconfigure a single plugin and stop.
+      // Selection state isn't saved (user didn't press enter); they can
+      // re-open `/runline-plugins` to make selection changes.
+      if (result.reconfigure) {
+        const target = result.reconfigure;
+        const updated = await promptForCredentials(
+          ctx,
+          runlineDir,
+          allPlugins,
+          [target],
+          { force: true },
+        );
+        ctx.ui.notify(
+          updated.length > 0
+            ? `credentials updated for ${target}`
+            : `reconfigure cancelled for ${target}`,
+          "info",
+        );
+        return;
+      }
 
       if (!result.selected) {
         ctx.ui.notify("plugin selection cancelled", "info");
@@ -281,57 +304,6 @@ export default function (pi: ExtensionAPI) {
         if (saved.length > 0) {
           ctx.ui.notify(
             `credentials saved for ${saved.length} plugin(s)`,
-            "info",
-          );
-        }
-      }
-
-      // Offer to reconfigure credentials for plugins that were already
-      // enabled and already have a stored connection. Without this, there
-      // is no path through `/runline-plugins` to re-enter an expired or
-      // mistyped token.
-      const connected = getConnectedPluginNames(runlineDir);
-      const reconfigurable = result.selected.filter(
-        (n) =>
-          previous.has(n) &&
-          connected.has(n) &&
-          allPlugins.some(
-            (p) =>
-              p.name === n &&
-              p.connectionConfigSchema &&
-              Object.keys(p.connectionConfigSchema).length > 0,
-          ),
-      );
-
-      let toReconfigure: string[] = [];
-      if (reconfigurable.length > 0) {
-        // Single multi-select picker so the user gets one screen instead of
-        // a chain of Y/N confirms.
-        const reconfigureItems = reconfigurable.map((name) => {
-          const p = allPlugins.find((pl) => pl.name === name);
-          return { name, actionCount: p?.actions.length ?? 0 };
-        });
-        const reconfigureResult = await ctx.ui.custom(
-          createPluginPickerFactory(reconfigureItems, []),
-          {
-            overlay: true,
-            overlayOptions: { width: "80%", maxHeight: "80%" },
-          },
-        );
-        toReconfigure = reconfigureResult.selected ?? [];
-      }
-
-      if (toReconfigure.length > 0) {
-        const updated = await promptForCredentials(
-          ctx,
-          runlineDir,
-          allPlugins,
-          toReconfigure,
-          { force: true },
-        );
-        if (updated.length > 0) {
-          ctx.ui.notify(
-            `credentials updated for ${updated.length} plugin(s)`,
             "info",
           );
         }

--- a/packages/pi-runline/extensions/runline-resolve.ts
+++ b/packages/pi-runline/extensions/runline-resolve.ts
@@ -60,6 +60,25 @@ export function loadExtConfig(runlineDir: string): RunlineExtConfig {
   }
 }
 
+/** Plugin names that already have a saved connection in .runline/config.json */
+export function getConnectedPluginNames(runlineDir: string): Set<string> {
+  const configPath = path.join(runlineDir, "config.json");
+  if (!fs.existsSync(configPath)) return new Set();
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    const conns = Array.isArray(raw.connections) ? raw.connections : [];
+    return new Set(
+      conns
+        .map((c: { plugin?: unknown }) =>
+          typeof c.plugin === "string" ? c.plugin : null,
+        )
+        .filter((n: string | null): n is string => n !== null),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 export function savePiPlugins(runlineDir: string, piPlugins: string[]): void {
   const configPath = path.join(runlineDir, "config.json");
   let raw: Record<string, unknown> = {};

--- a/packages/pi-runline/package.json
+++ b/packages/pi-runline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-runline",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Code mode for pi",
   "type": "commonjs",
   "keywords": [
@@ -22,7 +22,7 @@
     "lint:fix": "biome check --write extensions/"
   },
   "dependencies": {
-    "runline": "^0.5.1"
+    "runline": "^0.5.2"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",

--- a/packages/runline-plugins/jira/src/index.ts
+++ b/packages/runline-plugins/jira/src/index.ts
@@ -185,31 +185,49 @@ export default function jira(rl: RunlinePluginAPI) {
   });
 
   rl.registerAction("issue.search", {
-    description: "Search issues using JQL",
+    description:
+      "Search issues using JQL (uses /rest/api/3/search/jql; pagination is cursor-based via nextPageToken)",
     inputSchema: {
       jql: { type: "string", required: true, description: "JQL query" },
       fields: {
         type: "array",
         required: false,
-        description: "Fields to return",
+        description:
+          "Fields to return (e.g. ['summary','status']). Defaults to ['*all'] to match the legacy /search behavior.",
       },
       maxResults: {
         type: "number",
         required: false,
-        description: "Max results",
+        description: "Max results per page (server caps at 100)",
       },
-      startAt: { type: "number", required: false, description: "Start index" },
+      nextPageToken: {
+        type: "string",
+        required: false,
+        description:
+          "Cursor returned by the previous response. Pass to fetch the next page.",
+      },
+      expand: {
+        type: "string",
+        required: false,
+        description: "Comma-separated expansions",
+      },
     },
     async execute(input, ctx) {
-      const { jql, fields, maxResults, startAt } = input as Record<
-        string,
-        unknown
-      >;
-      const body: Record<string, unknown> = { jql };
-      if (fields) body.fields = fields;
+      const { jql, fields, maxResults, nextPageToken, expand } =
+        input as Record<string, unknown>;
+      const body: Record<string, unknown> = {
+        jql,
+        // The new endpoint returns only id+key by default; preserve the old
+        // "all navigable fields" behavior unless the caller specifies.
+        fields: Array.isArray(fields) ? fields : ["*all"],
+      };
       if (maxResults) body.maxResults = maxResults;
-      if (startAt) body.startAt = startAt;
-      return jr(ctx, "POST", "/api/2/search", body);
+      if (nextPageToken) body.nextPageToken = nextPageToken;
+      if (expand) body.expand = expand;
+      // Atlassian removed POST /rest/api/2|3/search (CHANGE-2046).
+      // The replacement endpoint is POST /rest/api/3/search/jql with
+      // cursor-based pagination.
+      return jr(ctx, "POST", "/api/3/search/jql", body);
     },
   });
 

--- a/packages/runline/package.json
+++ b/packages/runline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runline",
-  "version": "0.5.1",
-  "description": "Code mode for agents — turn any API or command into a callable action",
+  "version": "0.5.2",
+  "description": "Code mode for agents \u2014 turn any API or command into a callable action",
   "type": "module",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION
## Problem
`/runline-plugins` only shows plugins that already have a connection configured, so you can't use it to discover/enable a new plugin. Chicken-and-egg.

## Cause
`Runline.fromProject(cwd)` intentionally gates builtins by `config.connections[].plugin` for runtime safety. The pi-runline picker reused that instance via `rl.plugins()`, inheriting the same gating.

## Fix
The picker handler now calls `discoverPlugins(runlineDir)` directly (no allowlist) to get the full bundled catalog. Runtime gating via `fromProject` is unchanged. `promptForCredentials` also uses the full list so newly-enabled plugins can have their schemas resolved.