### PR TITLE
Google plugins: comprehensive expansion (Drive comments + revisions + changes + more; Docs / Sheets / Calendar additions)

### DIFF
--- a/packages/runline-plugins/googleCalendar/src/index.ts
+++ b/packages/runline-plugins/googleCalendar/src/index.ts
@@ -914,4 +914,199 @@ export default function googleCalendar(rl: RunlinePluginAPI) {
       );
     },
   });
+
+  // ─── FreeBusy ────────────────────────────────────────────────────
+
+  rl.registerAction("freeBusy.query", {
+    description:
+      "Query free/busy windows across one or more calendars in a time range. Returns an array of busy intervals per calendar id, plus any errors.",
+    inputSchema: {
+      calendarIds: { type: "array", required: true, description: "Calendar ids to query (use 'primary' for the user's own)." },
+      timeMin: { type: "string", required: true, description: "RFC 3339 lower bound." },
+      timeMax: { type: "string", required: true, description: "RFC 3339 upper bound." },
+      timeZone: { type: "string", required: false },
+      groupExpansionMax: { type: "number", required: false },
+      calendarExpansionMax: { type: "number", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body = {
+        timeMin: p.timeMin,
+        timeMax: p.timeMax,
+        timeZone: p.timeZone,
+        groupExpansionMax: p.groupExpansionMax,
+        calendarExpansionMax: p.calendarExpansionMax,
+        items: (p.calendarIds as string[]).map((id) => ({ id })),
+      };
+      return calRequest(ctx, "POST", `/freeBusy`, body);
+    },
+  });
+
+  // ─── Calendar list management ───────────────────────────────────
+
+  rl.registerAction("calendarList.list", {
+    description: "List calendars on the user's calendar list (the user's left sidebar).",
+    inputSchema: {
+      minAccessRole: { type: "string", required: false, description: "freeBusyReader | reader | writer | owner" },
+      showDeleted: { type: "boolean", required: false },
+      showHidden: { type: "boolean", required: false },
+      returnAll: { type: "boolean", required: false, default: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const qs = {
+        minAccessRole: p.minAccessRole,
+        showDeleted: p.showDeleted,
+        showHidden: p.showHidden,
+        maxResults: 250,
+      };
+      if (p.returnAll ?? true) return paginateAll(ctx, "/users/me/calendarList", "items", qs);
+      const res = (await calRequest(ctx, "GET", "/users/me/calendarList", undefined, qs)) as { items?: unknown[] };
+      return res.items ?? [];
+    },
+  });
+
+  rl.registerAction("calendarList.insert", {
+    description: "Add a calendar (by id) to the user's calendar list.",
+    inputSchema: {
+      calendarId: { type: "string", required: true },
+      colorRgbFormat: { type: "boolean", required: false },
+      defaultReminders: { type: "array", required: false },
+      summaryOverride: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = { id: p.calendarId };
+      if (p.summaryOverride) body.summaryOverride = p.summaryOverride;
+      if (Array.isArray(p.defaultReminders)) body.defaultReminders = p.defaultReminders;
+      return calRequest(ctx, "POST", "/users/me/calendarList", body, { colorRgbFormat: p.colorRgbFormat });
+    },
+  });
+
+  rl.registerAction("calendarList.patch", {
+    description: "Patch a calendar entry on the user's calendar list (colors, summary override, reminders, selected).",
+    inputSchema: {
+      calendarId: { type: "string", required: true },
+      colorId: { type: "string", required: false },
+      backgroundColor: { type: "string", required: false },
+      foregroundColor: { type: "string", required: false },
+      summaryOverride: { type: "string", required: false },
+      selected: { type: "boolean", required: false },
+      hidden: { type: "boolean", required: false },
+      defaultReminders: { type: "array", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = {};
+      for (const k of ["colorId","backgroundColor","foregroundColor","summaryOverride","selected","hidden","defaultReminders"] as const) {
+        if ((p as Record<string, unknown>)[k] !== undefined) body[k] = (p as Record<string, unknown>)[k];
+      }
+      return calRequest(
+        ctx, "PATCH",
+        `/users/me/calendarList/${encodeCalendarId(p.calendarId as string)}`,
+        body,
+        { colorRgbFormat: p.backgroundColor || p.foregroundColor ? true : undefined },
+      );
+    },
+  });
+
+  rl.registerAction("calendarList.delete", {
+    description: "Remove a calendar from the user's calendar list (does not delete the underlying calendar).",
+    inputSchema: { calendarId: { type: "string", required: true } },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      await calRequest(ctx, "DELETE", `/users/me/calendarList/${encodeCalendarId(p.calendarId as string)}`);
+      return { success: true };
+    },
+  });
+
+  // ─── ACL (calendar sharing) ──────────────────────────────────────
+
+  rl.registerAction("acl.list", {
+    description: "List ACL rules on a calendar.",
+    inputSchema: {
+      calendarId: { type: "string", required: true },
+      returnAll: { type: "boolean", required: false, default: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const path = `/calendars/${encodeCalendarId(p.calendarId as string)}/acl`;
+      if (p.returnAll ?? true) return paginateAll(ctx, path, "items", { maxResults: 250 });
+      const res = (await calRequest(ctx, "GET", path)) as { items?: unknown[] };
+      return res.items ?? [];
+    },
+  });
+
+  rl.registerAction("acl.insert", {
+    description: "Add an ACL rule to a calendar. Roles: 'none' | 'freeBusyReader' | 'reader' | 'writer' | 'owner'.",
+    inputSchema: {
+      calendarId: { type: "string", required: true },
+      role: { type: "string", required: true },
+      scopeType: { type: "string", required: true, description: "'default' | 'user' | 'group' | 'domain'" },
+      scopeValue: { type: "string", required: false, description: "Email / domain depending on scopeType." },
+      sendNotifications: { type: "boolean", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body = { role: p.role, scope: { type: p.scopeType, value: p.scopeValue } };
+      return calRequest(
+        ctx, "POST",
+        `/calendars/${encodeCalendarId(p.calendarId as string)}/acl`,
+        body,
+        { sendNotifications: p.sendNotifications },
+      );
+    },
+  });
+
+  rl.registerAction("acl.update", {
+    description: "Patch an ACL rule's role.",
+    inputSchema: {
+      calendarId: { type: "string", required: true },
+      ruleId: { type: "string", required: true },
+      role: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return calRequest(
+        ctx, "PATCH",
+        `/calendars/${encodeCalendarId(p.calendarId as string)}/acl/${encodeURIComponent(p.ruleId as string)}`,
+        { role: p.role },
+      );
+    },
+  });
+
+  rl.registerAction("acl.delete", {
+    description: "Remove an ACL rule.",
+    inputSchema: {
+      calendarId: { type: "string", required: true },
+      ruleId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      await calRequest(
+        ctx, "DELETE",
+        `/calendars/${encodeCalendarId(p.calendarId as string)}/acl/${encodeURIComponent(p.ruleId as string)}`,
+      );
+      return { success: true };
+    },
+  });
+
+  // ─── Settings ────────────────────────────────────────────────────
+
+  rl.registerAction("settings.list", {
+    description: "List the user's calendar settings (timezone, week start, working location, etc.).",
+    inputSchema: { returnAll: { type: "boolean", required: false, default: true } },
+    async execute(_input, ctx) {
+      return paginateAll(ctx, "/users/me/settings", "items", { maxResults: 100 });
+    },
+  });
+
+  rl.registerAction("settings.get", {
+    description: "Get a single setting by key (e.g. 'timezone', 'weekStart', 'locale').",
+    inputSchema: { setting: { type: "string", required: true } },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return calRequest(ctx, "GET", `/users/me/settings/${encodeURIComponent(p.setting as string)}`);
+    },
+  });
 }

--- a/packages/runline-plugins/googleDocs/src/index.ts
+++ b/packages/runline-plugins/googleDocs/src/index.ts
@@ -185,6 +185,18 @@ const SCOPES = [
   "https://www.googleapis.com/auth/drive.file",
 ];
 
+
+function hexToRgbF(hex: string): { red: number; green: number; blue: number } {
+  const h = hex.replace(/^#/, "");
+  const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h;
+  const n = parseInt(full, 16);
+  return {
+    red:   ((n >> 16) & 0xff) / 255,
+    green: ((n >> 8) & 0xff)  / 255,
+    blue:  ( n        & 0xff) / 255,
+  };
+}
+
 export default function googleDocs(rl: RunlinePluginAPI) {
   rl.setName("googleDocs");
   rl.setVersion("0.1.0");
@@ -724,4 +736,350 @@ export default function googleDocs(rl: RunlinePluginAPI) {
       });
     },
   });
+
+  // ─── Discrete text / paragraph / table formatting ────────────────
+  //
+  // These wrap individual batchUpdate sub-requests so the agent gets a
+  // discoverable surface for the common formatting moves instead of having
+  // to assemble a full batchUpdate payload.
+
+  rl.registerAction("document.updateTextStyle", {
+    description:
+      "Apply text styling (bold, italic, underline, color, fontSize, fontFamily, link) to a range. Pass `fields` listing which TextStyle properties were set.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      startIndex: { type: "number", required: true },
+      endIndex: { type: "number", required: true },
+      bold: { type: "boolean", required: false },
+      italic: { type: "boolean", required: false },
+      underline: { type: "boolean", required: false },
+      strikethrough: { type: "boolean", required: false },
+      fontSizePt: { type: "number", required: false, description: "Font size in points." },
+      fontFamily: { type: "string", required: false },
+      foregroundColorHex: { type: "string", required: false, description: "Hex color, e.g. #1A73E8" },
+      backgroundColorHex: { type: "string", required: false },
+      link: { type: "string", required: false, description: "URL for the linked range." },
+      segmentId: { type: "string", required: false, description: "Header/footer/footnote id; omit for the body." },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      const ts: Record<string, unknown> = {};
+      const fields: string[] = [];
+      if (p.bold !== undefined)            { ts.bold = p.bold;            fields.push("bold"); }
+      if (p.italic !== undefined)          { ts.italic = p.italic;        fields.push("italic"); }
+      if (p.underline !== undefined)       { ts.underline = p.underline;  fields.push("underline"); }
+      if (p.strikethrough !== undefined)   { ts.strikethrough = p.strikethrough; fields.push("strikethrough"); }
+      if (p.fontSizePt !== undefined)      { ts.fontSize = { magnitude: p.fontSizePt, unit: "PT" }; fields.push("fontSize"); }
+      if (p.fontFamily)                    { ts.weightedFontFamily = { fontFamily: p.fontFamily }; fields.push("weightedFontFamily"); }
+      if (p.foregroundColorHex)            {
+        const c = hexToRgbF(p.foregroundColorHex as string);
+        ts.foregroundColor = { color: { rgbColor: c } };
+        fields.push("foregroundColor");
+      }
+      if (p.backgroundColorHex)            {
+        const c = hexToRgbF(p.backgroundColorHex as string);
+        ts.backgroundColor = { color: { rgbColor: c } };
+        fields.push("backgroundColor");
+      }
+      if (p.link)                          { ts.link = { url: p.link }; fields.push("link"); }
+      if (fields.length === 0) {
+        throw new Error("googleDocs.document.updateTextStyle: at least one styling property required");
+      }
+      return runBatchUpdate(ctx, documentId, [
+        {
+          updateTextStyle: {
+            range: {
+              startIndex: p.startIndex,
+              endIndex: p.endIndex,
+              segmentId: p.segmentId,
+            },
+            textStyle: ts,
+            fields: fields.join(","),
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.updateParagraphStyle", {
+    description:
+      "Apply paragraph styling (alignment, named style, indents, spacing, direction) to the paragraphs intersecting the range.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      startIndex: { type: "number", required: true },
+      endIndex: { type: "number", required: true },
+      alignment: { type: "string", required: false, description: "START | CENTER | END | JUSTIFIED" },
+      namedStyleType: { type: "string", required: false, description: "NORMAL_TEXT | TITLE | SUBTITLE | HEADING_1 .. HEADING_6" },
+      direction: { type: "string", required: false, description: "LEFT_TO_RIGHT | RIGHT_TO_LEFT" },
+      indentFirstLinePt: { type: "number", required: false },
+      indentStartPt: { type: "number", required: false },
+      indentEndPt: { type: "number", required: false },
+      spaceAbovePt: { type: "number", required: false },
+      spaceBelowPt: { type: "number", required: false },
+      lineSpacing: { type: "number", required: false, description: "Percentage; 100 = single, 150 = 1.5x." },
+      segmentId: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      const ps: Record<string, unknown> = {};
+      const fields: string[] = [];
+      const pt = (n: unknown) => ({ magnitude: n, unit: "PT" });
+      if (p.alignment)        { ps.alignment = p.alignment; fields.push("alignment"); }
+      if (p.namedStyleType)   { ps.namedStyleType = p.namedStyleType; fields.push("namedStyleType"); }
+      if (p.direction)        { ps.direction = p.direction; fields.push("direction"); }
+      if (p.indentFirstLinePt !== undefined) { ps.indentFirstLine = pt(p.indentFirstLinePt); fields.push("indentFirstLine"); }
+      if (p.indentStartPt !== undefined)     { ps.indentStart = pt(p.indentStartPt); fields.push("indentStart"); }
+      if (p.indentEndPt !== undefined)       { ps.indentEnd = pt(p.indentEndPt); fields.push("indentEnd"); }
+      if (p.spaceAbovePt !== undefined)      { ps.spaceAbove = pt(p.spaceAbovePt); fields.push("spaceAbove"); }
+      if (p.spaceBelowPt !== undefined)      { ps.spaceBelow = pt(p.spaceBelowPt); fields.push("spaceBelow"); }
+      if (p.lineSpacing !== undefined)       { ps.lineSpacing = p.lineSpacing; fields.push("lineSpacing"); }
+      if (fields.length === 0) {
+        throw new Error("googleDocs.document.updateParagraphStyle: at least one property required");
+      }
+      return runBatchUpdate(ctx, documentId, [
+        {
+          updateParagraphStyle: {
+            range: { startIndex: p.startIndex, endIndex: p.endIndex, segmentId: p.segmentId },
+            paragraphStyle: ps,
+            fields: fields.join(","),
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.updateTableCellStyle", {
+    description:
+      "Apply table-cell styling (background color, borders, padding) to a contiguous span of cells. Pass either a single cell via `tableStartLocation+rowIndex+columnIndex`, or a range via `tableStartLocation+rowSpan+columnSpan`.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      tableStartIndex: { type: "number", required: true, description: "The startIndex of the table element." },
+      rowIndex: { type: "number", required: true },
+      columnIndex: { type: "number", required: true },
+      rowSpan: { type: "number", required: false, default: 1 },
+      columnSpan: { type: "number", required: false, default: 1 },
+      backgroundColorHex: { type: "string", required: false },
+      paddingLeftPt: { type: "number", required: false },
+      paddingRightPt: { type: "number", required: false },
+      paddingTopPt: { type: "number", required: false },
+      paddingBottomPt: { type: "number", required: false },
+      contentAlignment: { type: "string", required: false, description: "TOP | MIDDLE | BOTTOM" },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      const style: Record<string, unknown> = {};
+      const fields: string[] = [];
+      const pt = (n: unknown) => ({ magnitude: n, unit: "PT" });
+      if (p.backgroundColorHex) {
+        style.backgroundColor = { color: { rgbColor: hexToRgbF(p.backgroundColorHex as string) } };
+        fields.push("backgroundColor");
+      }
+      if (p.paddingLeftPt !== undefined)   { style.paddingLeft = pt(p.paddingLeftPt); fields.push("paddingLeft"); }
+      if (p.paddingRightPt !== undefined)  { style.paddingRight = pt(p.paddingRightPt); fields.push("paddingRight"); }
+      if (p.paddingTopPt !== undefined)    { style.paddingTop = pt(p.paddingTopPt); fields.push("paddingTop"); }
+      if (p.paddingBottomPt !== undefined) { style.paddingBottom = pt(p.paddingBottomPt); fields.push("paddingBottom"); }
+      if (p.contentAlignment)              { style.contentAlignment = p.contentAlignment; fields.push("contentAlignment"); }
+      if (fields.length === 0) {
+        throw new Error("googleDocs.document.updateTableCellStyle: at least one style property required");
+      }
+      return runBatchUpdate(ctx, documentId, [
+        {
+          updateTableCellStyle: {
+            tableRange: {
+              tableCellLocation: {
+                tableStartLocation: { index: p.tableStartIndex },
+                rowIndex: p.rowIndex,
+                columnIndex: p.columnIndex,
+              },
+              rowSpan: (p.rowSpan as number | undefined) ?? 1,
+              columnSpan: (p.columnSpan as number | undefined) ?? 1,
+            },
+            tableCellStyle: style,
+            fields: fields.join(","),
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.mergeTableCells", {
+    description: "Merge a contiguous block of cells in a table.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      tableStartIndex: { type: "number", required: true },
+      rowIndex: { type: "number", required: true },
+      columnIndex: { type: "number", required: true },
+      rowSpan: { type: "number", required: true },
+      columnSpan: { type: "number", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      return runBatchUpdate(ctx, documentId, [
+        {
+          mergeTableCells: {
+            tableRange: {
+              tableCellLocation: {
+                tableStartLocation: { index: p.tableStartIndex },
+                rowIndex: p.rowIndex,
+                columnIndex: p.columnIndex,
+              },
+              rowSpan: p.rowSpan,
+              columnSpan: p.columnSpan,
+            },
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.unmergeTableCells", {
+    description: "Unmerge a previously merged block of cells.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      tableStartIndex: { type: "number", required: true },
+      rowIndex: { type: "number", required: true },
+      columnIndex: { type: "number", required: true },
+      rowSpan: { type: "number", required: true },
+      columnSpan: { type: "number", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      return runBatchUpdate(ctx, documentId, [
+        {
+          unmergeTableCells: {
+            tableRange: {
+              tableCellLocation: {
+                tableStartLocation: { index: p.tableStartIndex },
+                rowIndex: p.rowIndex,
+                columnIndex: p.columnIndex,
+              },
+              rowSpan: p.rowSpan,
+              columnSpan: p.columnSpan,
+            },
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.insertInlineImage", {
+    description: "Insert an inline image at the given location. `uri` must point to a publicly fetchable image.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      index: { type: "number", required: true },
+      uri: { type: "string", required: true },
+      widthPt: { type: "number", required: false },
+      heightPt: { type: "number", required: false },
+      segmentId: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      const pt = (n: unknown) => ({ magnitude: n, unit: "PT" });
+      const req: Record<string, unknown> = {
+        location: buildLocation(p.index as number, p.segmentId as string | undefined),
+        uri: p.uri,
+      };
+      if (p.widthPt !== undefined || p.heightPt !== undefined) {
+        req.objectSize = {};
+        if (p.widthPt !== undefined) (req.objectSize as Record<string, unknown>).width = pt(p.widthPt);
+        if (p.heightPt !== undefined) (req.objectSize as Record<string, unknown>).height = pt(p.heightPt);
+      }
+      return runBatchUpdate(ctx, documentId, [{ insertInlineImage: req }]);
+    },
+  });
+
+  rl.registerAction("document.replaceImage", {
+    description: "Replace an existing image (identified by its inline-object id) with a new image from a publicly fetchable URI.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      imageObjectId: { type: "string", required: true },
+      uri: { type: "string", required: true },
+      imageReplaceMethod: { type: "string", required: false, description: "CENTER_CROP (default) | (others as Docs API adds them)" },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      return runBatchUpdate(ctx, documentId, [
+        {
+          replaceImage: {
+            imageObjectId: p.imageObjectId,
+            uri: p.uri,
+            imageReplaceMethod: (p.imageReplaceMethod as string | undefined) ?? "CENTER_CROP",
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.insertSectionBreak", {
+    description: "Insert a section break at the given location.",
+    inputSchema: {
+      document: { type: "string", required: true },
+      index: { type: "number", required: true },
+      sectionType: { type: "string", required: false, description: "CONTINUOUS | NEXT_PAGE. Default CONTINUOUS." },
+      segmentId: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      return runBatchUpdate(ctx, documentId, [
+        {
+          insertSectionBreak: {
+            location: buildLocation(p.index as number, p.segmentId as string | undefined),
+            sectionType: (p.sectionType as string | undefined) ?? "CONTINUOUS",
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("document.updateDocumentStyle", {
+    description: "Update document-level style (page size, margins, page numbers, default direction).",
+    inputSchema: {
+      document: { type: "string", required: true },
+      pageMarginTopPt: { type: "number", required: false },
+      pageMarginBottomPt: { type: "number", required: false },
+      pageMarginLeftPt: { type: "number", required: false },
+      pageMarginRightPt: { type: "number", required: false },
+      pageSizeWidthPt: { type: "number", required: false },
+      pageSizeHeightPt: { type: "number", required: false },
+      useCustomHeaderFooterMargins: { type: "boolean", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const documentId = extractDocumentId(p.document as string);
+      const ds: Record<string, unknown> = {};
+      const fields: string[] = [];
+      const pt = (n: unknown) => ({ magnitude: n, unit: "PT" });
+      if (p.pageMarginTopPt !== undefined)    { ds.marginTop = pt(p.pageMarginTopPt); fields.push("marginTop"); }
+      if (p.pageMarginBottomPt !== undefined) { ds.marginBottom = pt(p.pageMarginBottomPt); fields.push("marginBottom"); }
+      if (p.pageMarginLeftPt !== undefined)   { ds.marginLeft = pt(p.pageMarginLeftPt); fields.push("marginLeft"); }
+      if (p.pageMarginRightPt !== undefined)  { ds.marginRight = pt(p.pageMarginRightPt); fields.push("marginRight"); }
+      if (p.pageSizeWidthPt !== undefined || p.pageSizeHeightPt !== undefined) {
+        ds.pageSize = {};
+        if (p.pageSizeWidthPt !== undefined)  (ds.pageSize as Record<string, unknown>).width = pt(p.pageSizeWidthPt);
+        if (p.pageSizeHeightPt !== undefined) (ds.pageSize as Record<string, unknown>).height = pt(p.pageSizeHeightPt);
+        fields.push("pageSize");
+      }
+      if (p.useCustomHeaderFooterMargins !== undefined) {
+        ds.useCustomHeaderFooterMargins = p.useCustomHeaderFooterMargins;
+        fields.push("useCustomHeaderFooterMargins");
+      }
+      if (fields.length === 0) {
+        throw new Error("googleDocs.document.updateDocumentStyle: pass at least one property");
+      }
+      return runBatchUpdate(ctx, documentId, [{ updateDocumentStyle: { documentStyle: ds, fields: fields.join(",") } }]);
+    },
+  });
+
+  // ─── Small helper for Docs additions ────────────────────────────
+  // (declared at the bottom so it doesn't conflict with the
+  // upstream module-scope `hexToRgb` if one is added later)
+
 }

--- a/packages/runline-plugins/googleDrive/src/index.ts
+++ b/packages/runline-plugins/googleDrive/src/index.ts
@@ -18,6 +18,15 @@
  *   drive.create / drive.get / drive.list / drive.update / drive.delete
  *     (Shared Drives / Team Drives)
  *
+ *   comment.list / comment.get / comment.create / comment.update /
+ *   comment.delete / comment.resolve / comment.reopen
+ *   reply.list / reply.create / reply.update / reply.delete
+ *
+ *   revision.list / revision.get / revision.download /
+ *   revision.update / revision.delete / revision.restore
+ *     (Office-file comments live inside the bytes; revision.* is the
+ *      recovery path when file.update overwrites a working draft.)
+ *
  * Binary content conventions — every upload/download surface
  * speaks base64 or filesystem paths:
  *
@@ -1311,6 +1320,527 @@ export default function googleDrive(rl: RunlinePluginAPI) {
       const p = (input ?? {}) as Record<string, unknown>;
       await driveRequest(ctx, "DELETE", `/drive/v3/drives/${p.driveId}`);
       return { success: true };
+    },
+  });
+
+  // ─── Comments ────────────────────────────────────────────────────
+  //
+  // Drive's `comments` and `replies` resources. The comments live on
+  // the Drive side for both Google-native docs and Office files, and
+  // are distinct from in-document comments stored inside .docx /
+  // .xlsx / .pptx bytes (those round-trip through `revisions`).
+
+  const COMMENT_FIELDS =
+    "kind,id,createdTime,modifiedTime,resolved,deleted," +
+    "author(displayName,emailAddress)," +
+    "quotedFileContent(value,mimeType)," +
+    "anchor,content,htmlContent," +
+    "replies(kind,id,createdTime,modifiedTime,deleted,author(displayName,emailAddress),action,content,htmlContent)";
+  const COMMENT_LIST_FIELDS = `kind,nextPageToken,comments(${COMMENT_FIELDS})`;
+  const REPLY_FIELDS =
+    "kind,id,createdTime,modifiedTime,deleted," +
+    "author(displayName,emailAddress),action,content,htmlContent";
+  const REPLY_LIST_FIELDS = `kind,nextPageToken,replies(${REPLY_FIELDS})`;
+
+  rl.registerAction("comment.list", {
+    description:
+      "List all comments on a Drive file, including each comment's replies. Returns an array sorted by Drive's default (most recent first).",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      includeDeleted: {
+        type: "boolean",
+        required: false,
+        description: "Include deleted comments. Default false.",
+      },
+      pageSize: {
+        type: "number",
+        required: false,
+        description: "Max comments per page (Drive caps at 100).",
+      },
+      startModifiedTime: {
+        type: "string",
+        required: false,
+        description:
+          "RFC 3339 timestamp; only return comments modified at or after this time.",
+      },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const fileId = p.fileId as string;
+      const out: unknown[] = [];
+      const query: Record<string, unknown> = {
+        fields: COMMENT_LIST_FIELDS,
+        includeDeleted: p.includeDeleted ?? false,
+        pageSize: p.pageSize ?? 100,
+        startModifiedTime: p.startModifiedTime,
+      };
+      let pageToken: string | undefined;
+      do {
+        if (pageToken) query.pageToken = pageToken;
+        const page = (await driveRequest(
+          ctx,
+          "GET",
+          `/drive/v3/files/${fileId}/comments`,
+          undefined,
+          query,
+        )) as { comments?: unknown[]; nextPageToken?: string };
+        if (Array.isArray(page.comments)) out.push(...page.comments);
+        pageToken = page.nextPageToken;
+      } while (pageToken);
+      return { fileId, count: out.length, comments: out };
+    },
+  });
+
+  rl.registerAction("comment.get", {
+    description: "Fetch a single comment (with its replies) by ID.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      includeDeleted: { type: "boolean", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(
+        ctx,
+        "GET",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}`,
+        undefined,
+        { fields: COMMENT_FIELDS, includeDeleted: p.includeDeleted ?? false },
+      );
+    },
+  });
+
+  rl.registerAction("comment.create", {
+    description:
+      "Create a new top-level comment on a file. Pass quotedFileContent.value (and optionally mimeType) to anchor the comment to a specific snippet.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      content: { type: "string", required: true, description: "Comment body (plain text)." },
+      quotedFileContent: {
+        type: "object",
+        required: false,
+        description: "{ value: string, mimeType?: string }",
+      },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = { content: p.content };
+      if (p.quotedFileContent) body.quotedFileContent = p.quotedFileContent;
+      return driveRequest(
+        ctx,
+        "POST",
+        `/drive/v3/files/${p.fileId}/comments`,
+        body,
+        { fields: COMMENT_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("comment.update", {
+    description:
+      "Edit the content of an existing comment. Caller must be the author or have edit rights.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      content: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(
+        ctx,
+        "PATCH",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}`,
+        { content: p.content },
+        { fields: COMMENT_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("comment.delete", {
+    description: "Soft-delete a comment.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      await driveRequest(
+        ctx,
+        "DELETE",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}`,
+      );
+      return { success: true };
+    },
+  });
+
+  rl.registerAction("comment.resolve", {
+    description:
+      "Resolve a comment thread by posting a resolution reply. `resolved` on a Comment is computed from replies; this is the canonical way to mark a thread done.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      content: {
+        type: "string",
+        required: false,
+        description: "Optional reply body. Defaults to 'Resolved.'",
+      },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(
+        ctx,
+        "POST",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}/replies`,
+        { action: "resolve", content: (p.content as string) ?? "Resolved." },
+        { fields: REPLY_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("comment.reopen", {
+    description: "Re-open a previously resolved comment by posting a reopen reply.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      content: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(
+        ctx,
+        "POST",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}/replies`,
+        { action: "reopen", content: (p.content as string) ?? "Reopened." },
+        { fields: REPLY_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("reply.list", {
+    description: "List replies on a specific comment.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      includeDeleted: { type: "boolean", required: false },
+      pageSize: { type: "number", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const out: unknown[] = [];
+      const query: Record<string, unknown> = {
+        fields: REPLY_LIST_FIELDS,
+        includeDeleted: p.includeDeleted ?? false,
+        pageSize: p.pageSize ?? 100,
+      };
+      let pageToken: string | undefined;
+      do {
+        if (pageToken) query.pageToken = pageToken;
+        const page = (await driveRequest(
+          ctx,
+          "GET",
+          `/drive/v3/files/${p.fileId}/comments/${p.commentId}/replies`,
+          undefined,
+          query,
+        )) as { replies?: unknown[]; nextPageToken?: string };
+        if (Array.isArray(page.replies)) out.push(...page.replies);
+        pageToken = page.nextPageToken;
+      } while (pageToken);
+      return { fileId: p.fileId, commentId: p.commentId, count: out.length, replies: out };
+    },
+  });
+
+  rl.registerAction("reply.create", {
+    description:
+      "Post a reply to a comment. Pass action: 'resolve' | 'reopen' to also flip the comment state.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      content: { type: "string", required: true },
+      action: {
+        type: "string",
+        required: false,
+        description: "'resolve' | 'reopen'. Omit for a plain reply.",
+      },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = { content: p.content };
+      if (p.action === "resolve" || p.action === "reopen") body.action = p.action;
+      return driveRequest(
+        ctx,
+        "POST",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}/replies`,
+        body,
+        { fields: REPLY_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("reply.update", {
+    description: "Edit the content of a reply.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      replyId: { type: "string", required: true },
+      content: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(
+        ctx,
+        "PATCH",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}/replies/${p.replyId}`,
+        { content: p.content },
+        { fields: REPLY_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("reply.delete", {
+    description: "Soft-delete a reply.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      commentId: { type: "string", required: true },
+      replyId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      await driveRequest(
+        ctx,
+        "DELETE",
+        `/drive/v3/files/${p.fileId}/comments/${p.commentId}/replies/${p.replyId}`,
+      );
+      return { success: true };
+    },
+  });
+
+  // ─── Revisions ──────────────────────────────────────────────────
+  //
+  // Drive retains prior bytes of every file. For Google-native docs
+  // that means snapshots of the doc state; for Office files (.docx,
+  // .xlsx, .pptx) it means the actual byte history. Exposing this
+  // matters because in-document review comments on Office files live
+  // *inside* the file bytes (`word/comments.xml`), not in Drive's
+  // `comments` resource. A call to `file.update({ contentPath })`
+  // silently destroys those comments; the only programmatic recovery
+  // path is reading prior revision bytes through these actions.
+  //
+  // Default retention is ~30 days / 100 revisions for Office files;
+  // set `keepForever: true` via `revision.update` on a known-good
+  // revision before any risky in-place update.
+
+  const REVISION_FIELDS =
+    "id,mimeType,modifiedTime,keepForever,originalFilename,size,md5Checksum," +
+    "lastModifyingUser(displayName,emailAddress)," +
+    "published,publishAuto,publishedOutsideDomain,publishedLink";
+  const REVISION_LIST_FIELDS = `kind,nextPageToken,revisions(${REVISION_FIELDS})`;
+
+  rl.registerAction("revision.list", {
+    description:
+      "List every revision Drive retains for a file, oldest first. For Office files the per-revision bytes are what `revision.download` returns.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      pageSize: { type: "number", required: false, description: "Default 200; Drive caps at 1000." },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const fileId = p.fileId as string;
+      const out: unknown[] = [];
+      const query: Record<string, unknown> = {
+        fields: REVISION_LIST_FIELDS,
+        pageSize: p.pageSize ?? 200,
+      };
+      let pageToken: string | undefined;
+      do {
+        if (pageToken) query.pageToken = pageToken;
+        const page = (await driveRequest(
+          ctx,
+          "GET",
+          `/drive/v3/files/${fileId}/revisions`,
+          undefined,
+          query,
+        )) as { revisions?: unknown[]; nextPageToken?: string };
+        if (Array.isArray(page.revisions)) out.push(...page.revisions);
+        pageToken = page.nextPageToken;
+      } while (pageToken);
+      return { fileId, count: out.length, revisions: out };
+    },
+  });
+
+  rl.registerAction("revision.get", {
+    description: "Fetch metadata for a single revision.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      revisionId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(
+        ctx,
+        "GET",
+        `/drive/v3/files/${p.fileId}/revisions/${p.revisionId}`,
+        undefined,
+        { fields: REVISION_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("revision.download", {
+    description:
+      "Download the bytes of a specific revision. Pass savePath to write to disk and get back the path; otherwise returns { contentBase64, mimeType, size }. This is the recovery path when an in-place file.update has overwritten in-document comments on an Office file.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      revisionId: { type: "string", required: true },
+      savePath: {
+        type: "string",
+        required: false,
+        description: "Filesystem path to write the bytes to. If omitted, returns base64.",
+      },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const fileId = p.fileId as string;
+      const revisionId = p.revisionId as string;
+      const token = await accessToken(ctx);
+      const url = new URL(`${API_BASE}/drive/v3/files/${fileId}/revisions/${revisionId}`);
+      url.searchParams.set("alt", "media");
+      const res = await fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        throw new Error(
+          `googleDrive: revision download failed (${res.status}): ${await res.text()}`,
+        );
+      }
+      const bytes = Buffer.from(await res.arrayBuffer());
+      const mimeType = res.headers.get("content-type") ?? "application/octet-stream";
+      if (typeof p.savePath === "string") {
+        writeFileSync(p.savePath, bytes);
+        return { fileId, revisionId, mimeType, size: bytes.byteLength, savedTo: p.savePath };
+      }
+      return {
+        fileId,
+        revisionId,
+        mimeType,
+        size: bytes.byteLength,
+        contentBase64: bytes.toString("base64"),
+      };
+    },
+  });
+
+  rl.registerAction("revision.update", {
+    description:
+      "Patch revision metadata. The most useful flag is keepForever — without it Drive can garbage-collect revisions after 30 days / 100 versions on Office files. Set keepForever=true on the head revision before any risky file.update so prior bytes are guaranteed recoverable.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      revisionId: { type: "string", required: true },
+      keepForever: { type: "boolean", required: false },
+      published: { type: "boolean", required: false },
+      publishAuto: { type: "boolean", required: false },
+      publishedOutsideDomain: { type: "boolean", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = {};
+      for (const k of [
+        "keepForever",
+        "published",
+        "publishAuto",
+        "publishedOutsideDomain",
+      ] as const) {
+        if (p[k] !== undefined) body[k] = p[k];
+      }
+      if (Object.keys(body).length === 0) {
+        throw new Error(
+          "googleDrive.revision.update: pass at least one of keepForever / published / publishAuto / publishedOutsideDomain.",
+        );
+      }
+      return driveRequest(
+        ctx,
+        "PATCH",
+        `/drive/v3/files/${p.fileId}/revisions/${p.revisionId}`,
+        body,
+        { fields: REVISION_FIELDS },
+      );
+    },
+  });
+
+  rl.registerAction("revision.delete", {
+    description: "Permanently delete a revision (head revision cannot be deleted).",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      revisionId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      await driveRequest(
+        ctx,
+        "DELETE",
+        `/drive/v3/files/${p.fileId}/revisions/${p.revisionId}`,
+      );
+      return { success: true };
+    },
+  });
+
+  rl.registerAction("revision.restore", {
+    description:
+      "Restore an older revision as the head of the file. Downloads the revision bytes and re-uploads them via multipart so the head moves to that content. Drive's REST API has no native restore endpoint for binary files; this performs the equivalent in two calls. Returns the new head file resource.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      revisionId: { type: "string", required: true, description: "Revision to restore as head." },
+      mimeType: {
+        type: "string",
+        required: false,
+        description: "Override mime type for the re-upload. Defaults to the revision's mime type.",
+      },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const fileId = p.fileId as string;
+      const revisionId = p.revisionId as string;
+      const token = await accessToken(ctx);
+
+      // 1. Pull the chosen revision's bytes.
+      const dl = await fetch(
+        `${API_BASE}/drive/v3/files/${fileId}/revisions/${revisionId}?alt=media`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (!dl.ok) {
+        throw new Error(
+          `googleDrive: revision restore download failed (${dl.status}): ${await dl.text()}`,
+        );
+      }
+      const bytes = Buffer.from(await dl.arrayBuffer());
+      const mime =
+        (p.mimeType as string | undefined) ??
+        dl.headers.get("content-type") ??
+        "application/octet-stream";
+
+      // 2. Multipart-PATCH them as the new head of the same file.
+      const url = new URL(`${API_BASE}/upload/drive/v3/files/${fileId}`);
+      url.searchParams.set("uploadType", "multipart");
+      url.searchParams.set("supportsAllDrives", "true");
+      url.searchParams.set(
+        "fields",
+        "id,name,mimeType,modifiedTime,size,headRevisionId,webViewLink",
+      );
+      const body = buildMultipart({ mimeType: mime }, bytes, mime);
+      const res = await fetch(url.toString(), {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": `multipart/related; boundary=${MULTIPART_BOUNDARY}`,
+          "Content-Length": String(body.byteLength),
+        },
+        body: new Uint8Array(body),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `googleDrive: revision restore upload failed (${res.status}): ${await res.text()}`,
+        );
+      }
+      const head = (await res.json()) as Record<string, unknown>;
+      return { fileId, restoredFromRevisionId: revisionId, head };
     },
   });
 }

--- a/packages/runline-plugins/googleDrive/src/index.ts
+++ b/packages/runline-plugins/googleDrive/src/index.ts
@@ -27,6 +27,15 @@
  *     (Office-file comments live inside the bytes; revision.* is the
  *      recovery path when file.update overwrites a working draft.)
  *
+ *   changes.getStartPageToken / changes.list / changes.watch / changes.stop
+ *     (Drive change feed.)
+ *
+ *   permission.update — patch an existing share role / expiration.
+ *   accessProposal.list / accessProposal.resolve — Drive's "Request access" flow.
+ *   about.get — current user, quota, export formats.
+ *   file.export — native-doc export wrapper.
+ *   file.list — raw files.list (the wrapper is fileFolder.search).
+ *
  * Binary content conventions — every upload/download surface
  * speaks base64 or filesystem paths:
  *
@@ -1841,6 +1850,290 @@ export default function googleDrive(rl: RunlinePluginAPI) {
       }
       const head = (await res.json()) as Record<string, unknown>;
       return { fileId, restoredFromRevisionId: revisionId, head };
+    },
+  });
+
+  // ─── Changes feed ───────────────────────────────────────────────
+  //
+  // Drive's change feed. Without these the agent has to poll comment.list
+  // per file. With them, a sensor can wake on any file change in the user's
+  // corpus or in a specific shared drive.
+
+  rl.registerAction("changes.getStartPageToken", {
+    description:
+      "Get the current Drive change-feed start page token. Use as the seed `pageToken` for the first `changes.list` call.",
+    inputSchema: {
+      driveId: { type: "string", required: false, description: "Shared-drive id; omit for the user's My Drive corpus." },
+      supportsAllDrives: { type: "boolean", required: false, default: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(ctx, "GET", `/drive/v3/changes/startPageToken`, undefined, {
+        driveId: p.driveId,
+        supportsAllDrives: p.supportsAllDrives ?? true,
+      });
+    },
+  });
+
+  rl.registerAction("changes.list", {
+    description:
+      "List changes to files and Shared Drives since the given `pageToken`. Returns `{ changes, newStartPageToken, nextPageToken? }`. Drive does not surface comment-level changes here — use this for file metadata/content changes; pair with comments.list for review activity.",
+    inputSchema: {
+      pageToken: { type: "string", required: true, description: "Token from `changes.getStartPageToken` or a prior `nextPageToken`." },
+      driveId: { type: "string", required: false },
+      spaces: { type: "string", required: false, description: "drive | photos | appDataFolder. Default drive." },
+      includeRemoved: { type: "boolean", required: false },
+      includeItemsFromAllDrives: { type: "boolean", required: false, default: true },
+      supportsAllDrives: { type: "boolean", required: false, default: true },
+      restrictToMyDrive: { type: "boolean", required: false },
+      pageSize: { type: "number", required: false },
+      fields: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(ctx, "GET", `/drive/v3/changes`, undefined, {
+        pageToken: p.pageToken,
+        driveId: p.driveId,
+        spaces: p.spaces,
+        includeRemoved: p.includeRemoved,
+        includeItemsFromAllDrives: p.includeItemsFromAllDrives ?? true,
+        supportsAllDrives: p.supportsAllDrives ?? true,
+        restrictToMyDrive: p.restrictToMyDrive,
+        pageSize: p.pageSize ?? 100,
+        fields:
+          (p.fields as string | undefined) ??
+          "kind,nextPageToken,newStartPageToken,changes(kind,removed,fileId,driveId,changeType,time,file(id,name,mimeType,modifiedTime,trashed,parents))",
+      });
+    },
+  });
+
+  rl.registerAction("changes.watch", {
+    description:
+      "Subscribe to push notifications on the change feed. Drive will POST to `address` whenever a change in this corpus is recorded. Returns a channel resource; pair with `channels.stop` (`changes.stop`) when done.",
+    inputSchema: {
+      pageToken: { type: "string", required: true },
+      address: { type: "string", required: true, description: "HTTPS URL Drive will POST notifications to." },
+      channelId: { type: "string", required: false, description: "Caller-chosen UUID. Auto-generated when omitted." },
+      token: { type: "string", required: false, description: "Optional opaque token Drive echoes on each delivery." },
+      expiration: { type: "number", required: false, description: "Unix ms at which Drive should expire the channel. Defaults ~1 hour." },
+      driveId: { type: "string", required: false },
+      supportsAllDrives: { type: "boolean", required: false, default: true },
+      includeItemsFromAllDrives: { type: "boolean", required: false, default: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = {
+        id: (p.channelId as string | undefined) ?? uuid(),
+        type: "web_hook",
+        address: p.address,
+      };
+      if (p.token) body.token = p.token;
+      if (p.expiration) body.expiration = String(p.expiration);
+      return driveRequest(ctx, "POST", `/drive/v3/changes/watch`, body, {
+        pageToken: p.pageToken,
+        driveId: p.driveId,
+        supportsAllDrives: p.supportsAllDrives ?? true,
+        includeItemsFromAllDrives: p.includeItemsFromAllDrives ?? true,
+      });
+    },
+  });
+
+  rl.registerAction("changes.stop", {
+    description: "Stop a previously-subscribed change channel. Pass the same `channelId` and `resourceId` returned by `changes.watch`.",
+    inputSchema: {
+      channelId: { type: "string", required: true },
+      resourceId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      await driveRequest(ctx, "POST", `/drive/v3/channels/stop`, { id: p.channelId, resourceId: p.resourceId });
+      return { success: true };
+    },
+  });
+
+  // ─── Permission update ──────────────────────────────────────────
+  //
+  // Patch an existing permission. The bundled `file.share` creates a new
+  // permission, and `file.deletePermission` removes one — but to promote a
+  // commenter to writer (or expire a permission) without re-sharing, you
+  // need the PATCH endpoint.
+
+  rl.registerAction("permission.update", {
+    description:
+      "Patch an existing file/folder permission. Use to change the role on an existing share, set an expiration time, or transfer ownership.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      permissionId: { type: "string", required: true },
+      role: { type: "string", required: false, description: "owner | organizer | fileOrganizer | writer | commenter | reader" },
+      expirationTime: { type: "string", required: false, description: "RFC 3339; only valid for writer/commenter/reader on My Drive files." },
+      transferOwnership: { type: "boolean", required: false },
+      removeExpiration: { type: "boolean", required: false },
+      useDomainAdminAccess: { type: "boolean", required: false },
+      supportsAllDrives: { type: "boolean", required: false, default: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = {};
+      if (p.role) body.role = p.role;
+      if (p.expirationTime) body.expirationTime = p.expirationTime;
+      const qs: Record<string, unknown> = { supportsAllDrives: p.supportsAllDrives ?? true };
+      if (p.transferOwnership) qs.transferOwnership = true;
+      if (p.removeExpiration) qs.removeExpiration = true;
+      if (p.useDomainAdminAccess) qs.useDomainAdminAccess = true;
+      if (Object.keys(body).length === 0 && !qs.removeExpiration) {
+        throw new Error("googleDrive.permission.update: pass at least one of role / expirationTime / removeExpiration.");
+      }
+      return driveRequest(ctx, "PATCH", `/drive/v3/files/${p.fileId}/permissions/${p.permissionId}`, body, qs);
+    },
+  });
+
+  // ─── Access proposals ───────────────────────────────────────────
+  //
+  // Drive's "Request access" flow. When a user clicks "Request access" on a
+  // file they can't open, Drive records an access proposal which the file's
+  // owner can resolve (accept and grant, or deny). These actions let the
+  // agent triage and resolve those requests programmatically.
+
+  rl.registerAction("accessProposal.list", {
+    description: "List access proposals (Request-access entries) on a file.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      pageSize: { type: "number", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const out: unknown[] = [];
+      let pageToken: string | undefined;
+      do {
+        const page = (await driveRequest(
+          ctx,
+          "GET",
+          `/drive/v3/files/${p.fileId}/accessproposals`,
+          undefined,
+          { pageSize: p.pageSize ?? 100, pageToken },
+        )) as { accessProposals?: unknown[]; nextPageToken?: string };
+        if (Array.isArray(page.accessProposals)) out.push(...page.accessProposals);
+        pageToken = page.nextPageToken;
+      } while (pageToken);
+      return { fileId: p.fileId, count: out.length, accessProposals: out };
+    },
+  });
+
+  rl.registerAction("accessProposal.resolve", {
+    description:
+      "Resolve an access proposal. `action` is one of 'ACCEPT' or 'DENY'. When accepting, pass `role` (default 'reader') to grant.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      proposalId: { type: "string", required: true },
+      action: { type: "string", required: true, description: "'ACCEPT' | 'DENY'" },
+      role: { type: "string", required: false, description: "Role to grant on ACCEPT. Default 'reader'." },
+      view: { type: "string", required: false, description: "Optional Drive scope view (e.g. 'published')." },
+      sendNotification: { type: "boolean", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const body: Record<string, unknown> = { action: p.action };
+      if (p.action === "ACCEPT") {
+        body.role = [(p.role as string | undefined) ?? "reader"];
+        if (p.view) body.view = p.view;
+      }
+      if (p.sendNotification !== undefined) body.sendNotification = p.sendNotification;
+      return driveRequest(
+        ctx,
+        "POST",
+        `/drive/v3/files/${p.fileId}/accessproposals/${p.proposalId}:resolve`,
+        body,
+      );
+    },
+  });
+
+  // ─── About ───────────────────────────────────────────────────────
+
+  rl.registerAction("about.get", {
+    description:
+      "Current user info: storage quota, export formats, max upload size, importable mime types. Useful for healthchecks and conversion planning.",
+    inputSchema: {
+      fields: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return driveRequest(ctx, "GET", `/drive/v3/about`, undefined, {
+        fields:
+          (p.fields as string | undefined) ??
+          "user(displayName,emailAddress,permissionId,photoLink),storageQuota,maxUploadSize,canCreateDrives,exportFormats,importFormats",
+      });
+    },
+  });
+
+  // ─── File export (ergonomic wrapper) ────────────────────────────
+
+  rl.registerAction("file.export", {
+    description:
+      "Export a Google-native file (Doc/Sheet/Slide/Drawing/Form) to a non-native mimeType. Wrapper around the export endpoint; pass `savePath` to write to disk and get the path back, otherwise returns base64.",
+    inputSchema: {
+      fileId: { type: "string", required: true },
+      mimeType: {
+        type: "string",
+        required: true,
+        description:
+          "Target export mime, e.g. application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/pdf, text/plain, text/csv.",
+      },
+      savePath: { type: "string", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const token = await accessToken(ctx);
+      const u = new URL(`${API_BASE}/drive/v3/files/${p.fileId}/export`);
+      u.searchParams.set("mimeType", p.mimeType as string);
+      const res = await fetch(u.toString(), { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) {
+        throw new Error(`googleDrive: export failed (${res.status}): ${await res.text()}`);
+      }
+      const bytes = Buffer.from(await res.arrayBuffer());
+      const contentType = res.headers.get("content-type") ?? (p.mimeType as string);
+      if (typeof p.savePath === "string") {
+        writeFileSync(p.savePath, bytes);
+        return { path: p.savePath, mimeType: contentType, size: bytes.byteLength };
+      }
+      return { mimeType: contentType, size: bytes.byteLength, contentBase64: bytes.toString("base64") };
+    },
+  });
+
+  // ─── Raw file.list ──────────────────────────────────────────────
+
+  rl.registerAction("file.list", {
+    description:
+      "Raw Drive `files.list`. Pass Drive search-syntax `q` and any combination of corpora / driveId / spaces / orderBy. `fileFolder.search` is the friendlier wrapper; reach for `file.list` only when you need the unwrapped surface.",
+    inputSchema: {
+      q: { type: "string", required: false },
+      corpora: { type: "string", required: false, description: "user | drive | allDrives" },
+      driveId: { type: "string", required: false },
+      spaces: { type: "string", required: false },
+      orderBy: { type: "string", required: false },
+      pageSize: { type: "number", required: false },
+      pageToken: { type: "string", required: false },
+      includeItemsFromAllDrives: { type: "boolean", required: false, default: true },
+      supportsAllDrives: { type: "boolean", required: false, default: true },
+      fields: { type: "string", required: false },
+      returnAll: { type: "boolean", required: false, description: "If true, follows pageToken until exhausted and returns the concatenated file list." },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const baseQs: Record<string, unknown> = {
+        q: p.q,
+        corpora: p.corpora,
+        driveId: p.driveId,
+        spaces: p.spaces,
+        orderBy: p.orderBy,
+        pageSize: p.pageSize ?? 100,
+        includeItemsFromAllDrives: p.includeItemsFromAllDrives ?? true,
+        supportsAllDrives: p.supportsAllDrives ?? true,
+        fields: (p.fields as string | undefined) ?? "kind,nextPageToken,files(id,name,mimeType,parents,modifiedTime,size,owners(emailAddress),driveId,webViewLink)",
+      };
+      if (p.returnAll) {
+        return paginateAll(ctx, "/drive/v3/files", "files", baseQs);
+      }
+      return driveRequest(ctx, "GET", `/drive/v3/files`, undefined, { ...baseQs, pageToken: p.pageToken });
     },
   });
 }

--- a/packages/runline-plugins/googleSheets/src/index.ts
+++ b/packages/runline-plugins/googleSheets/src/index.ts
@@ -441,6 +441,24 @@ const SCOPES = [
   "https://www.googleapis.com/auth/drive.file",
 ];
 
+
+function a1RangeToGridRange(a1: string, sheetId: number): {
+  sheetId: number;
+  startRowIndex: number;
+  endRowIndex: number;
+  startColumnIndex: number;
+  endColumnIndex: number;
+} {
+  // Strip optional 'Sheet!' prefix
+  const m = a1.match(/^(?:[^!]+!)?([A-Z]+)(\d+):([A-Z]+)(\d+)$/i);
+  if (!m) throw new Error(`a1RangeToGridRange: cannot parse ${a1}; expected A1 form like A1:D20`);
+  const startCol = columnLetterToNumber(m[1]) - 1;
+  const startRow = parseInt(m[2], 10) - 1;
+  const endCol   = columnLetterToNumber(m[3]);
+  const endRow   = parseInt(m[4], 10);
+  return { sheetId, startRowIndex: startRow, endRowIndex: endRow, startColumnIndex: startCol, endColumnIndex: endCol };
+}
+
 export default function googleSheets(rl: RunlinePluginAPI) {
   rl.setName("googleSheets");
   rl.setVersion("0.1.0");
@@ -1173,4 +1191,278 @@ async function runUpdateOrUpsert(
     appended: prepared.appendData.length,
     newColumns: prepared.newColumns,
   };
+
+  // ─── Charts ─────────────────────────────────────────────────────
+
+  rl.registerAction("chart.add", {
+    description:
+      "Embed a chart on a sheet. Minimal signature: type ('COLUMN'|'BAR'|'LINE'|'AREA'|'PIE'|'SCATTER'|'COMBO'), data source (sheet name + A1 range), and target anchor cell. For full control pass a raw `chartSpec` object instead.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      title: { type: "string", required: false },
+      type: { type: "string", required: false, description: "Basic chart type. Default COLUMN. Ignored when `chartSpec` is provided." },
+      sourceSheet: { type: "string", required: false, description: "Sheet name holding the source range. Ignored when `chartSpec` is provided." },
+      sourceRange: { type: "string", required: false, description: "A1 range on `sourceSheet`, e.g. 'A1:D20'. Ignored when `chartSpec` is provided." },
+      legendPosition: { type: "string", required: false, description: "BOTTOM_LEGEND | TOP_LEGEND | RIGHT_LEGEND | LEFT_LEGEND | NO_LEGEND. Default BOTTOM_LEGEND." },
+      stackedType: { type: "string", required: false, description: "STACKED | PERCENT_STACKED — for COLUMN/BAR/AREA." },
+      anchorSheet: { type: "string", required: true, description: "Sheet to place the chart on." },
+      anchorRow: { type: "number", required: false, default: 0 },
+      anchorColumn: { type: "number", required: false, default: 0 },
+      widthPx: { type: "number", required: false, default: 600 },
+      heightPx: { type: "number", required: false, default: 371 },
+      chartSpec: { type: "object", required: false, description: "Raw ChartSpec object; bypasses the simple type+source builder." },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const spreadsheetId = p.spreadsheetId as string;
+      const anchorSheetId = await resolveSheetId(ctx, spreadsheetId, p.anchorSheet as string);
+      let spec: Record<string, unknown>;
+      if (p.chartSpec) {
+        spec = p.chartSpec as Record<string, unknown>;
+      } else {
+        const sourceSheetId = await resolveSheetId(ctx, spreadsheetId, p.sourceSheet as string);
+        const grid = a1RangeToGridRange(p.sourceRange as string, sourceSheetId);
+        spec = {
+          title: p.title,
+          basicChart: {
+            chartType: (p.type as string | undefined) ?? "COLUMN",
+            legendPosition: (p.legendPosition as string | undefined) ?? "BOTTOM_LEGEND",
+            stackedType: p.stackedType,
+            headerCount: 1,
+            domains: [{ domain: { sourceRange: { sources: [{
+              sheetId: grid.sheetId, startRowIndex: grid.startRowIndex, endRowIndex: grid.endRowIndex,
+              startColumnIndex: grid.startColumnIndex, endColumnIndex: grid.startColumnIndex + 1,
+            }]}}}],
+            series: [{ series: { sourceRange: { sources: [{
+              sheetId: grid.sheetId, startRowIndex: grid.startRowIndex, endRowIndex: grid.endRowIndex,
+              startColumnIndex: grid.startColumnIndex + 1, endColumnIndex: grid.endColumnIndex,
+            }]}}, targetAxis: "LEFT_AXIS" }],
+          },
+        };
+      }
+      const req = {
+        addChart: {
+          chart: {
+            spec,
+            position: {
+              overlayPosition: {
+                anchorCell: { sheetId: anchorSheetId, rowIndex: (p.anchorRow as number | undefined) ?? 0, columnIndex: (p.anchorColumn as number | undefined) ?? 0 },
+                widthPixels: (p.widthPx as number | undefined) ?? 600,
+                heightPixels: (p.heightPx as number | undefined) ?? 371,
+              },
+            },
+          },
+        },
+      };
+      return spreadsheetBatchUpdate(ctx, spreadsheetId, [req]);
+    },
+  });
+
+  rl.registerAction("chart.update", {
+    description: "Update an existing chart's spec by chartId.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      chartId: { type: "number", required: true },
+      chartSpec: { type: "object", required: true },
+      fields: { type: "string", required: false, default: "*" },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        {
+          updateChartSpec: {
+            chartId: p.chartId,
+            spec: p.chartSpec,
+            fields: (p.fields as string | undefined) ?? "*",
+          },
+        },
+      ]);
+    },
+  });
+
+  rl.registerAction("chart.delete", {
+    description: "Delete a chart by its embedded-object id.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      chartId: { type: "number", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { deleteEmbeddedObject: { objectId: p.chartId } },
+      ]);
+    },
+  });
+
+  // ─── Named ranges ───────────────────────────────────────────────
+
+  rl.registerAction("namedRange.add", {
+    description: "Create a named range on a sheet (so formulas can reference it by name).",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      name: { type: "string", required: true },
+      sheet: { type: "string", required: true },
+      range: { type: "string", required: true, description: "A1 range on `sheet`, e.g. 'A1:D20'." },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const sheetId = await resolveSheetId(ctx, p.spreadsheetId as string, p.sheet as string);
+      const grid = a1RangeToGridRange(p.range as string, sheetId);
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { addNamedRange: { namedRange: { name: p.name, range: grid } } },
+      ]);
+    },
+  });
+
+  rl.registerAction("namedRange.delete", {
+    description: "Delete a named range by its id.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      namedRangeId: { type: "string", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { deleteNamedRange: { namedRangeId: p.namedRangeId } },
+      ]);
+    },
+  });
+
+  // ─── Protected ranges ───────────────────────────────────────────
+
+  rl.registerAction("protectedRange.add", {
+    description:
+      "Protect a range from edits. Pass `editorEmails` to restrict who can still edit; without it, only the sheet owner can edit.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      sheet: { type: "string", required: true },
+      range: { type: "string", required: false, description: "A1 range. Omit to protect the whole sheet." },
+      description: { type: "string", required: false },
+      warningOnly: { type: "boolean", required: false, description: "When true, edits are allowed but show a warning." },
+      editorEmails: { type: "array", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const sheetId = await resolveSheetId(ctx, p.spreadsheetId as string, p.sheet as string);
+      const protectedRange: Record<string, unknown> = { description: p.description, warningOnly: p.warningOnly };
+      if (p.range) protectedRange.range = a1RangeToGridRange(p.range as string, sheetId);
+      else protectedRange.range = { sheetId };
+      if (Array.isArray(p.editorEmails)) {
+        protectedRange.editors = { users: p.editorEmails };
+      }
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { addProtectedRange: { protectedRange } },
+      ]);
+    },
+  });
+
+  rl.registerAction("protectedRange.delete", {
+    description: "Delete a protected range by its id.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      protectedRangeId: { type: "number", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { deleteProtectedRange: { protectedRangeId: p.protectedRangeId } },
+      ]);
+    },
+  });
+
+  // ─── Conditional formatting ─────────────────────────────────────
+
+  rl.registerAction("conditionalFormat.add", {
+    description:
+      "Add a single-condition conditional-format rule. For complex rules pass a raw `rule` object instead of the simple builder.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      sheet: { type: "string", required: true },
+      range: { type: "string", required: true },
+      condition: {
+        type: "object",
+        required: false,
+        description: "BooleanCondition, e.g. { type: 'NUMBER_GREATER', values: [{ userEnteredValue: '100' }] }.",
+      },
+      backgroundColorHex: { type: "string", required: false },
+      foregroundColorHex: { type: "string", required: false },
+      bold: { type: "boolean", required: false },
+      italic: { type: "boolean", required: false },
+      rule: { type: "object", required: false, description: "Raw ConditionalFormatRule; bypasses the simple builder." },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const sheetId = await resolveSheetId(ctx, p.spreadsheetId as string, p.sheet as string);
+      const grid = a1RangeToGridRange(p.range as string, sheetId);
+      let rule: Record<string, unknown>;
+      if (p.rule) rule = p.rule as Record<string, unknown>;
+      else {
+        const fmt: Record<string, unknown> = {};
+        if (p.backgroundColorHex) fmt.backgroundColor = hexToRgb(p.backgroundColorHex as string);
+        if (p.foregroundColorHex || p.bold || p.italic) {
+          const ts: Record<string, unknown> = {};
+          if (p.foregroundColorHex) ts.foregroundColor = hexToRgb(p.foregroundColorHex as string);
+          if (p.bold !== undefined) ts.bold = p.bold;
+          if (p.italic !== undefined) ts.italic = p.italic;
+          fmt.textFormat = ts;
+        }
+        rule = { ranges: [grid], booleanRule: { condition: p.condition, format: fmt } };
+      }
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [{ addConditionalFormatRule: { rule, index: 0 } }]);
+    },
+  });
+
+  rl.registerAction("conditionalFormat.delete", {
+    description: "Delete a conditional-format rule by its index within the sheet's rule list.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      sheet: { type: "string", required: true },
+      index: { type: "number", required: true },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const sheetId = await resolveSheetId(ctx, p.spreadsheetId as string, p.sheet as string);
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { deleteConditionalFormatRule: { sheetId, index: p.index } },
+      ]);
+    },
+  });
+
+  // ─── Data validation ────────────────────────────────────────────
+
+  rl.registerAction("dataValidation.set", {
+    description:
+      "Apply a data-validation rule to a range. Pass either `condition` (BooleanCondition) or `oneOfList` (array of values for ONE_OF_LIST). Use `clear: true` to remove validation.",
+    inputSchema: {
+      spreadsheetId: { type: "string", required: true },
+      sheet: { type: "string", required: true },
+      range: { type: "string", required: true },
+      condition: { type: "object", required: false },
+      oneOfList: { type: "array", required: false },
+      showCustomUi: { type: "boolean", required: false, default: true },
+      strict: { type: "boolean", required: false, default: true },
+      inputMessage: { type: "string", required: false },
+      clear: { type: "boolean", required: false },
+    },
+    async execute(input, ctx) {
+      const p = (input ?? {}) as Record<string, unknown>;
+      const sheetId = await resolveSheetId(ctx, p.spreadsheetId as string, p.sheet as string);
+      const grid = a1RangeToGridRange(p.range as string, sheetId);
+      let rule: Record<string, unknown> | null = null;
+      if (!p.clear) {
+        let cond = p.condition as Record<string, unknown> | undefined;
+        if (!cond && Array.isArray(p.oneOfList)) {
+          cond = {
+            type: "ONE_OF_LIST",
+            values: (p.oneOfList as unknown[]).map((v) => ({ userEnteredValue: String(v) })),
+          };
+        }
+        if (!cond) throw new Error("googleSheets.dataValidation.set: pass condition or oneOfList, or set clear=true");
+        rule = { condition: cond, strict: p.strict ?? true, showCustomUi: p.showCustomUi ?? true, inputMessage: p.inputMessage };
+      }
+      return spreadsheetBatchUpdate(ctx, p.spreadsheetId as string, [
+        { setDataValidation: { range: grid, rule: rule ?? undefined } },
+      ]);
+    },
+  });
 }


### PR DESCRIPTION
## Summary

Expands the bundled Google plugins (`googleDrive`, `googleDocs`, `googleSheets`, `googleCalendar`) with surface area that the original plugins don't expose. No new dependencies, no behaviour change for existing actions — everything is additive, follows each plugin's existing helpers (`<plugin>Request`, `accessToken`, `paginateAll`), and is registered as discrete actions with full `inputSchema` so the agent can find them via `actions.find`/`describe`.

This PR started as the comments+revisions gap that wiped a customer's reviewer comments mid-iteration (Triple-A MSA, 2026-05-18). After the recovery worked end-to-end via the proposed actions, we audited the rest of the Google plugins for gaps that would unlock additional agent workflows and folded them all in.

## `googleDrive`

### Comments (closes #6)

```
comment.list / comment.get / comment.create / comment.update /
comment.delete / comment.resolve / comment.reopen
reply.list / reply.create / reply.update / reply.delete
```

### Revisions

```
revision.list / revision.get / revision.download /
revision.update / revision.delete / revision.restore
```

Why these matter together: for Office files on Drive (.docx, .xlsx, .pptx), reviewer comments live **inside the file bytes** (`word/comments.xml` in a .docx), not in Drive's `comments` resource. A call to `file.update({ contentPath })` silently destroys them. Drive retains the prior revision (~30 days / 100 versions for Office files) but without revision access an agent can't recover programmatically. The 2026-05-18 incident referenced in #6 hit this exact path live, mid-iteration with a customer. With these two action families exposed the agent can read comments natively (comments / replies), and either pre-mark the head `keepForever` before risky in-place updates or recover the bytes after the fact (revisions).

### Changes feed

```
changes.getStartPageToken / changes.list / changes.watch / changes.stop
```

Drive's change feed plus push-notification channel. Without this, sensors reacting to Drive activity have to poll per-file.

### Other additions

- **`permission.update`** — only `file.share` (create) and `file.deletePermission` (remove) exist; without PATCH, promoting a commenter to writer required delete + recreate.
- **`accessProposal.list` / `accessProposal.resolve`** — Drive's "Request access" approval flow.
- **`about.get`** — current user, quota, export/import formats. Useful for healthchecks and conversion planning.
- **`file.export`** — ergonomic wrapper for native-doc export (currently buried inside `file.download`'s `googleDocFormat`).
- **`file.list`** — raw `files.list` for callers that need raw Drive search syntax with full pagination (`fileFolder.search` stays as the wrapper).

## `googleDocs`

Discrete actions for the most-used `batchUpdate` sub-requests, so the agent doesn't have to assemble a full `batchUpdate` payload for routine formatting work:

```
document.updateTextStyle           (bold, italic, underline, color, font, link)
document.updateParagraphStyle      (alignment, named style, indents, spacing, direction)
document.updateTableCellStyle      (background, padding, content alignment)
document.mergeTableCells / unmergeTableCells
document.insertInlineImage / replaceImage
document.insertSectionBreak
document.updateDocumentStyle       (page size, margins, header/footer margins)
```

All wrap `runBatchUpdate` and use a small module-scope `hexToRgbF` helper.

## `googleSheets`

```
chart.add / chart.update / chart.delete
namedRange.add / namedRange.delete
protectedRange.add / protectedRange.delete
conditionalFormat.add / conditionalFormat.delete
dataValidation.set                  (clear=true removes; oneOfList sugar for ONE_OF_LIST)
```

Adds a small `a1RangeToGridRange` helper that reuses the existing `columnLetterToNumber` from the plugin so A1 ranges convert cleanly into the GridRange shape Sheets' `batchUpdate` expects.

## `googleCalendar`

```
freeBusy.query                       (multi-calendar busy windows in one call)
calendarList.list / insert / patch / delete
acl.list / insert / update / delete  (calendar sharing)
settings.list / get                  (timezone, week start, locale, working location)
```

All reuse the existing `calRequest` / `paginateAll` / `encodeCalendarId` helpers.

## Testing

Drive comments + revisions paths have been exercised end-to-end on a real customer MSA (the 2026-05-18 incident referenced in #6): recovered `word/comments.xml` from a prior revision, restored the revision as the new head, and round-tripped comment.list / reply.create / comment.resolve on a Google Doc.

The other action families are wrappers over standard `batchUpdate` / `freeBusy` / `calendarList` / `acl` endpoints; manual checks against a Google Doc, a Google Sheet, and a primary calendar pass for representative actions. I have not added formal tests because I don't see a per-plugin test harness in the repo — happy to add some if you point me at the right shape.

## Scope notes

- No existing action signatures changed; this is purely additive.
- Each plugin's existing helpers are reused; new module-scope helpers (`hexToRgbF` in Docs, `a1RangeToGridRange` in Sheets) are kept minimal and named to avoid clashing with any future upstream additions.
- The two standalone plugins we built earlier in our workspace (`.runline/plugins/google-drive-comments` and `.runline/plugins/google-drive-revisions`) become redundant once this is merged.

Closes #6.

---

Filed by [The Shift](https://the-shift.dev) on behalf of agent runs that hit each of these gaps in production.