### PR TITLE
Add Microsoft Graph plugins: microsoftMail, microsoftCalendar, microsoftFiles

### DIFF
--- a/packages/runline-plugins/_shared/microsoftAuth.ts
+++ b/packages/runline-plugins/_shared/microsoftAuth.ts
@@ -8,7 +8,8 @@ const REFRESH_SKEW_MS = 60_000;
  * Two modes, auto-detected from the connection config:
  *
  *  - Delegated (OAuth2): the connection has clientId/clientSecret/refreshToken
- *    (seeded by Vex's OAuth wizard). Acts as the signed-in user; use /me paths.
+ *    (seeded by the OAuth flow, e.g. `runline auth`). Acts as the signed-in
+ *    user; use /me paths.
  *  - App-only (client credentials): the connection has tenantId/clientId/
  *    clientSecret but no refreshToken. Acts as the application; target a mailbox/
  *    drive with userUpn → /users/{upn} paths.
@@ -131,7 +132,7 @@ export async function graphRequest(
   return text ? JSON.parse(text) : { success: true };
 }
 
-/** Setup help shown by Vex's OAuth wizard for all Microsoft plugins. */
+/** Setup help shown by the OAuth wizard for all Microsoft plugins. */
 export function microsoftSetupHelp(apiName: string): string[] {
   return [
     `You need a Microsoft Entra (Azure AD) app registration. One-time, ~5 minutes.`,

--- a/packages/runline-plugins/_shared/microsoftAuth.ts
+++ b/packages/runline-plugins/_shared/microsoftAuth.ts
@@ -1,0 +1,148 @@
+import type { ActionContext } from "runline";
+
+const REFRESH_SKEW_MS = 60_000;
+
+/**
+ * Shared auth for the Microsoft Graph plugins (mail, calendar, files).
+ *
+ * Two modes, auto-detected from the connection config:
+ *
+ *  - Delegated (OAuth2): the connection has clientId/clientSecret/refreshToken
+ *    (seeded by Vex's OAuth wizard). Acts as the signed-in user; use /me paths.
+ *  - App-only (client credentials): the connection has tenantId/clientId/
+ *    clientSecret but no refreshToken. Acts as the application; target a mailbox/
+ *    drive with userUpn → /users/{upn} paths.
+ *
+ * Tokens are cached in the connection (accessToken + accessTokenExpiresAt) via
+ * ctx.updateConnection, matching the Google plugins' pattern.
+ */
+export type MicrosoftAuthConfig = {
+  tenantId?: string;
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  userUpn?: string;
+  accessToken?: string;
+  accessTokenExpiresAt?: number;
+};
+
+function authority(cfg: MicrosoftAuthConfig): string {
+  return `https://login.microsoftonline.com/${cfg.tenantId || "common"}/oauth2/v2.0/token`;
+}
+
+export function isAppOnly(cfg: MicrosoftAuthConfig): boolean {
+  return !cfg.refreshToken && !!(cfg.tenantId && cfg.clientId && cfg.clientSecret);
+}
+
+/** Graph path prefix for the acting principal: /me (delegated) or /users/{upn} (app-only). */
+export function userBase(ctx: ActionContext): string {
+  const cfg = ctx.connection.config as MicrosoftAuthConfig;
+  if (cfg.refreshToken) return "/me";
+  if (cfg.userUpn) return `/users/${encodeURIComponent(cfg.userUpn)}`;
+  throw new Error(
+    "microsoft: app-only mode requires userUpn (target mailbox/drive). Set MS_GRAPH_USER_UPN, or connect via OAuth.",
+  );
+}
+
+export async function microsoftAccessToken(
+  ctx: ActionContext,
+  pluginName: string,
+  scopes: string[],
+): Promise<string> {
+  const cfg = ctx.connection.config as MicrosoftAuthConfig;
+  if (
+    cfg.accessToken &&
+    typeof cfg.accessTokenExpiresAt === "number" &&
+    Date.now() < cfg.accessTokenExpiresAt - REFRESH_SKEW_MS
+  ) {
+    return cfg.accessToken;
+  }
+
+  let body: URLSearchParams;
+  if (cfg.refreshToken) {
+    if (!cfg.clientId || !cfg.clientSecret) {
+      throw new Error(`${pluginName}: missing clientId/clientSecret for OAuth refresh.`);
+    }
+    body = new URLSearchParams({
+      client_id: cfg.clientId,
+      client_secret: cfg.clientSecret,
+      refresh_token: cfg.refreshToken,
+      grant_type: "refresh_token",
+      scope: [...scopes, "offline_access"].join(" "),
+    });
+  } else if (isAppOnly(cfg)) {
+    body = new URLSearchParams({
+      client_id: cfg.clientId as string,
+      client_secret: cfg.clientSecret as string,
+      grant_type: "client_credentials",
+      scope: "https://graph.microsoft.com/.default",
+    });
+  } else {
+    throw new Error(
+      `${pluginName}: no credentials. Connect via OAuth, or set tenantId/clientId/clientSecret (app-only).`,
+    );
+  }
+
+  const res = await fetch(authority(cfg), {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`${pluginName}: token request failed (${res.status}): ${await res.text()}`);
+  }
+  const data = (await res.json()) as {
+    access_token: string;
+    expires_in: number;
+    refresh_token?: string;
+  };
+  const patch: Record<string, unknown> = {
+    accessToken: data.access_token,
+    accessTokenExpiresAt: Date.now() + data.expires_in * 1000,
+  };
+  // Microsoft rotates refresh tokens — persist the new one when present.
+  if (data.refresh_token) patch.refreshToken = data.refresh_token;
+  await ctx.updateConnection(patch);
+  return data.access_token;
+}
+
+/** Authenticated Graph v1.0 request. Returns parsed JSON ({success:true} for 204). */
+export async function graphRequest(
+  ctx: ActionContext,
+  pluginName: string,
+  scopes: string[],
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<any> {
+  const token = await microsoftAccessToken(ctx, pluginName, scopes);
+  const init: RequestInit = {
+    method,
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+  };
+  if (body !== undefined) {
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`https://graph.microsoft.com/v1.0${path}`, init);
+  if (res.status === 204) return { success: true };
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${pluginName}: ${method} ${path} → ${res.status} ${text}`);
+  return text ? JSON.parse(text) : { success: true };
+}
+
+/** Setup help shown by Vex's OAuth wizard for all Microsoft plugins. */
+export function microsoftSetupHelp(apiName: string): string[] {
+  return [
+    `You need a Microsoft Entra (Azure AD) app registration. One-time, ~5 minutes.`,
+    "",
+    "1. Register an app: https://entra.microsoft.com → App registrations → New registration.",
+    "   Supported account types: your org (single tenant) is fine.",
+    "2. Add a Web redirect URI (Authentication → Add platform → Web):",
+    "     {{redirectUri}}",
+    "3. Certificates & secrets → New client secret → copy the VALUE (not the Secret ID).",
+    `4. API permissions → Add → Microsoft Graph → Delegated → add the ${apiName} scopes,`,
+    "   then 'Grant admin consent'.",
+    "5. Paste the Application (client) ID and the client secret VALUE below.",
+  ];
+}

--- a/packages/runline-plugins/microsoftCalendar/src/index.ts
+++ b/packages/runline-plugins/microsoftCalendar/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Microsoft Outlook calendar plugin for runline (Microsoft Graph).
+ *
+ * Auth: shared "microsoft" OAuth family (delegated → /me) or app-only
+ * (tenantId/clientId/clientSecret + userUpn). See _shared/microsoftAuth.ts.
+ * Graph delegated scopes: Calendars.Read.
+ */
+import type { ActionContext, RunlinePluginAPI } from "runline";
+import { graphRequest, microsoftSetupHelp, userBase } from "../../_shared/microsoftAuth.js";
+
+const NAME = "microsoftCalendar";
+const SCOPES = ["https://graph.microsoft.com/Calendars.Read"];
+type Ctx = ActionContext;
+
+export default function microsoftCalendar(rl: RunlinePluginAPI): void {
+  rl.setName(NAME);
+  rl.setVersion("1.0.0");
+
+  rl.setConnectionSchema({
+    tenantId: { type: "string", required: false, env: "MS_GRAPH_TENANT_ID", description: "Entra tenant id (app-only) or omit for OAuth /common" },
+    clientId: { type: "string", required: false, env: "MS_GRAPH_CLIENT_ID", description: "App (client) id" },
+    clientSecret: { type: "string", required: false, env: "MS_GRAPH_CLIENT_SECRET", description: "Client secret VALUE" },
+    userUpn: { type: "string", required: false, env: "MS_GRAPH_USER_UPN", description: "App-only only: target user UPN" },
+  });
+
+  rl.setOAuth({
+    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    scopes: [...SCOPES, "offline_access"],
+    authParams: { prompt: "consent" },
+    setupHelp: microsoftSetupHelp("Calendars.Read"),
+  });
+
+  rl.registerAction("calendar.list", {
+    description:
+      "List calendar events in a date range. Returns [{id,subject,start,end,location,organizer,attendees}].",
+    inputSchema: {
+      start: { type: "string", required: true, description: "ISO start datetime, e.g. 2026-05-01T00:00:00Z" },
+      end: { type: "string", required: true, description: "ISO end datetime" },
+      top: { type: "number", required: false, default: 50 },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const qs = new URLSearchParams({
+        startDateTime: input.start,
+        endDateTime: input.end,
+        $top: String(input.top ?? 50),
+        $select: "id,subject,start,end,location,organizer,attendees,isAllDay,webLink",
+        $orderby: "start/dateTime",
+      });
+      const r = await graphRequest(ctx, NAME, SCOPES, "GET", `${userBase(ctx)}/calendarView?${qs}`);
+      return r.value;
+    },
+  });
+
+  rl.registerAction("event.get", {
+    description: "Get one calendar event by id (full details incl. body).",
+    inputSchema: { id: { type: "string", required: true } },
+    async execute(input: any, ctx: Ctx) {
+      return graphRequest(ctx, NAME, SCOPES, "GET", `${userBase(ctx)}/events/${input.id}`);
+    },
+  });
+}

--- a/packages/runline-plugins/microsoftCalendar/src/index.ts
+++ b/packages/runline-plugins/microsoftCalendar/src/index.ts
@@ -20,6 +20,7 @@ export default function microsoftCalendar(rl: RunlinePluginAPI): void {
     tenantId: { type: "string", required: false, env: "MS_GRAPH_TENANT_ID", description: "Entra tenant id (app-only) or omit for OAuth /common" },
     clientId: { type: "string", required: false, env: "MS_GRAPH_CLIENT_ID", description: "App (client) id" },
     clientSecret: { type: "string", required: false, env: "MS_GRAPH_CLIENT_SECRET", description: "Client secret VALUE" },
+    refreshToken: { type: "string", required: false, env: "MICROSOFTCALENDAR_REFRESH_TOKEN", description: "OAuth2 refresh token (set by the login flow)" },
     userUpn: { type: "string", required: false, env: "MS_GRAPH_USER_UPN", description: "App-only only: target user UPN" },
   });
 

--- a/packages/runline-plugins/microsoftCalendar/src/index.ts
+++ b/packages/runline-plugins/microsoftCalendar/src/index.ts
@@ -28,7 +28,6 @@ export default function microsoftCalendar(rl: RunlinePluginAPI): void {
     authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     scopes: [...SCOPES, "offline_access"],
-    authParams: { prompt: "consent" },
     setupHelp: microsoftSetupHelp("Calendars.Read"),
   });
 

--- a/packages/runline-plugins/microsoftFiles/src/index.ts
+++ b/packages/runline-plugins/microsoftFiles/src/index.ts
@@ -122,7 +122,7 @@ export default function microsoftFiles(rl: RunlinePluginAPI): void {
     description:
       "Upload a file (base64) to a path in the drive, e.g. a dedicated output folder. Returns the created item. For files up to ~4MB.",
     inputSchema: {
-      path: { type: "string", required: true, description: "Drive-relative path incl. filename, e.g. 'Vex Output/report.docx'" },
+      path: { type: "string", required: true, description: "Drive-relative path incl. filename, e.g. 'Agent Output/report.docx'" },
       base64: { type: "string", required: true, description: "File content, base64-encoded" },
     },
     async execute(input: any, ctx: Ctx) {

--- a/packages/runline-plugins/microsoftFiles/src/index.ts
+++ b/packages/runline-plugins/microsoftFiles/src/index.ts
@@ -32,15 +32,15 @@ function driveBase(ctx: Ctx): string {
 
 async function binaryFetch(ctx: Ctx, method: string, path: string, body?: Uint8Array) {
   const token = await microsoftAccessToken(ctx, NAME, SCOPES);
-  const res = await fetch(`https://graph.microsoft.com/v1.0${path}`, {
+  const init: RequestInit = {
     method,
     headers: {
       Authorization: `Bearer ${token}`,
       ...(body ? { "Content-Type": "application/octet-stream" } : {}),
     },
-    body: body as BodyInit | undefined,
-  });
-  return res;
+  };
+  if (body) init.body = body;
+  return fetch(`https://graph.microsoft.com/v1.0${path}`, init);
 }
 
 export default function microsoftFiles(rl: RunlinePluginAPI): void {
@@ -72,7 +72,7 @@ export default function microsoftFiles(rl: RunlinePluginAPI): void {
       top: { type: "number", required: false, default: 25 },
     },
     async execute(input: any, ctx: Ctx) {
-      const q = encodeURIComponent(input.query);
+      const q = encodeURIComponent(String(input.query).replace(/'/g, "''"));
       const qs = new URLSearchParams({
         $top: String(input.top ?? 25),
         $select: "id,name,size,lastModifiedDateTime,webUrl,folder,file",

--- a/packages/runline-plugins/microsoftFiles/src/index.ts
+++ b/packages/runline-plugins/microsoftFiles/src/index.ts
@@ -1,0 +1,152 @@
+/**
+ * Microsoft OneDrive / SharePoint files plugin for runline (Microsoft Graph).
+ *
+ * Auth: shared "microsoft" OAuth family (delegated → /me/drive) or app-only
+ * (tenantId/clientId/clientSecret + userUpn → /users/{upn}/drive). Optionally
+ * target a SharePoint document library with siteId/driveId. See
+ * _shared/microsoftAuth.ts. Graph delegated scopes: Files.ReadWrite.All,
+ * Sites.ReadWrite.All (use the .Read.* variants if you only need reads).
+ */
+import type { ActionContext, RunlinePluginAPI } from "runline";
+import {
+  graphRequest,
+  microsoftAccessToken,
+  microsoftSetupHelp,
+  userBase,
+} from "../../_shared/microsoftAuth.js";
+
+const NAME = "microsoftFiles";
+const SCOPES = [
+  "https://graph.microsoft.com/Files.ReadWrite.All",
+  "https://graph.microsoft.com/Sites.ReadWrite.All",
+];
+type Ctx = ActionContext;
+
+/** Resolve the drive root path: explicit drive/site, else the user's default drive. */
+function driveBase(ctx: Ctx): string {
+  const cfg = ctx.connection.config as Record<string, string>;
+  if (cfg.driveId) return `/drives/${cfg.driveId}`;
+  if (cfg.siteId) return `/sites/${cfg.siteId}/drive`;
+  return `${userBase(ctx)}/drive`;
+}
+
+async function binaryFetch(ctx: Ctx, method: string, path: string, body?: Uint8Array) {
+  const token = await microsoftAccessToken(ctx, NAME, SCOPES);
+  const res = await fetch(`https://graph.microsoft.com/v1.0${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body ? { "Content-Type": "application/octet-stream" } : {}),
+    },
+    body: body as BodyInit | undefined,
+  });
+  return res;
+}
+
+export default function microsoftFiles(rl: RunlinePluginAPI): void {
+  rl.setName(NAME);
+  rl.setVersion("1.0.0");
+
+  rl.setConnectionSchema({
+    tenantId: { type: "string", required: false, env: "MS_GRAPH_TENANT_ID", description: "Entra tenant id (app-only) or omit for OAuth /common" },
+    clientId: { type: "string", required: false, env: "MS_GRAPH_CLIENT_ID", description: "App (client) id" },
+    clientSecret: { type: "string", required: false, env: "MS_GRAPH_CLIENT_SECRET", description: "Client secret VALUE" },
+    userUpn: { type: "string", required: false, env: "MS_GRAPH_USER_UPN", description: "App-only only: target user UPN (their OneDrive)" },
+    siteId: { type: "string", required: false, env: "MS_SHAREPOINT_SITE_ID", description: "Optional SharePoint site id (use its default drive)" },
+    driveId: { type: "string", required: false, env: "MS_GRAPH_DRIVE_ID", description: "Optional explicit drive id (overrides site/user)" },
+  });
+
+  rl.setOAuth({
+    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    scopes: [...SCOPES, "offline_access"],
+    authParams: { prompt: "consent" },
+    setupHelp: microsoftSetupHelp("Files.ReadWrite.All, Sites.ReadWrite.All"),
+  });
+
+  rl.registerAction("files.search", {
+    description:
+      "Search the drive for files/folders by text. Returns [{id,name,size,lastModifiedDateTime,webUrl,folder?}].",
+    inputSchema: {
+      query: { type: "string", required: true },
+      top: { type: "number", required: false, default: 25 },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const q = encodeURIComponent(input.query);
+      const qs = new URLSearchParams({
+        $top: String(input.top ?? 25),
+        $select: "id,name,size,lastModifiedDateTime,webUrl,folder,file",
+      });
+      const r = await graphRequest(ctx, NAME, SCOPES, "GET", `${driveBase(ctx)}/root/search(q='${q}')?${qs}`);
+      return r.value;
+    },
+  });
+
+  rl.registerAction("files.list", {
+    description: "List children of a folder (default the drive root, or pass folderId).",
+    inputSchema: {
+      folderId: { type: "string", required: false, description: "Folder item id; omit for root" },
+      top: { type: "number", required: false, default: 100 },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const where = input.folderId ? `/items/${input.folderId}/children` : "/root/children";
+      const qs = new URLSearchParams({
+        $top: String(input.top ?? 100),
+        $select: "id,name,size,lastModifiedDateTime,webUrl,folder,file",
+      });
+      const r = await graphRequest(ctx, NAME, SCOPES, "GET", `${driveBase(ctx)}${where}?${qs}`);
+      return r.value;
+    },
+  });
+
+  rl.registerAction("files.get", {
+    description:
+      "Download a file by id. Returns {id,name,size,contentType,base64}. base64 is the file bytes.",
+    inputSchema: { id: { type: "string", required: true } },
+    async execute(input: any, ctx: Ctx) {
+      const meta = await graphRequest(ctx, NAME, SCOPES, "GET", `${driveBase(ctx)}/items/${input.id}`);
+      const res = await binaryFetch(ctx, "GET", `${driveBase(ctx)}/items/${input.id}/content`);
+      if (!res.ok) throw new Error(`${NAME}: download ${input.id} → ${res.status} ${await res.text()}`);
+      const buf = Buffer.from(await res.arrayBuffer());
+      return {
+        id: meta.id,
+        name: meta.name,
+        size: meta.size,
+        contentType: meta.file?.mimeType,
+        base64: buf.toString("base64"),
+      };
+    },
+  });
+
+  rl.registerAction("files.upload", {
+    description:
+      "Upload a file (base64) to a path in the drive, e.g. a dedicated output folder. Returns the created item. For files up to ~4MB.",
+    inputSchema: {
+      path: { type: "string", required: true, description: "Drive-relative path incl. filename, e.g. 'Vex Output/report.docx'" },
+      base64: { type: "string", required: true, description: "File content, base64-encoded" },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const bytes = Buffer.from(input.base64, "base64");
+      const p = input.path.split("/").map(encodeURIComponent).join("/");
+      const res = await binaryFetch(ctx, "PUT", `${driveBase(ctx)}/root:/${p}:/content`, bytes);
+      if (!res.ok) throw new Error(`${NAME}: upload ${input.path} → ${res.status} ${await res.text()}`);
+      return JSON.parse(await res.text());
+    },
+  });
+
+  rl.registerAction("folder.create", {
+    description: "Create a folder (e.g. a dedicated agent output folder) under the drive root or a parent.",
+    inputSchema: {
+      name: { type: "string", required: true },
+      parentId: { type: "string", required: false, description: "Parent folder id; omit for root" },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const where = input.parentId ? `/items/${input.parentId}/children` : "/root/children";
+      return graphRequest(ctx, NAME, SCOPES, "POST", `${driveBase(ctx)}${where}`, {
+        name: input.name,
+        folder: {},
+        "@microsoft.graph.conflictBehavior": "rename",
+      });
+    },
+  });
+}

--- a/packages/runline-plugins/microsoftFiles/src/index.ts
+++ b/packages/runline-plugins/microsoftFiles/src/index.ts
@@ -61,7 +61,6 @@ export default function microsoftFiles(rl: RunlinePluginAPI): void {
     authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     scopes: [...SCOPES, "offline_access"],
-    authParams: { prompt: "consent" },
     setupHelp: microsoftSetupHelp("Files.ReadWrite.All, Sites.ReadWrite.All"),
   });
 

--- a/packages/runline-plugins/microsoftFiles/src/index.ts
+++ b/packages/runline-plugins/microsoftFiles/src/index.ts
@@ -51,6 +51,7 @@ export default function microsoftFiles(rl: RunlinePluginAPI): void {
     tenantId: { type: "string", required: false, env: "MS_GRAPH_TENANT_ID", description: "Entra tenant id (app-only) or omit for OAuth /common" },
     clientId: { type: "string", required: false, env: "MS_GRAPH_CLIENT_ID", description: "App (client) id" },
     clientSecret: { type: "string", required: false, env: "MS_GRAPH_CLIENT_SECRET", description: "Client secret VALUE" },
+    refreshToken: { type: "string", required: false, env: "MICROSOFTFILES_REFRESH_TOKEN", description: "OAuth2 refresh token (set by the login flow)" },
     userUpn: { type: "string", required: false, env: "MS_GRAPH_USER_UPN", description: "App-only only: target user UPN (their OneDrive)" },
     siteId: { type: "string", required: false, env: "MS_SHAREPOINT_SITE_ID", description: "Optional SharePoint site id (use its default drive)" },
     driveId: { type: "string", required: false, env: "MS_GRAPH_DRIVE_ID", description: "Optional explicit drive id (overrides site/user)" },

--- a/packages/runline-plugins/microsoftMail/src/index.ts
+++ b/packages/runline-plugins/microsoftMail/src/index.ts
@@ -2,7 +2,7 @@
  * Microsoft Outlook mail plugin for runline (Microsoft Graph).
  *
  * Auth: Microsoft identity platform OAuth2 (delegated, acts as the signed-in
- * user → /me) seeded by Vex's OAuth wizard; or app-only client credentials
+ * user → /me) seeded by the OAuth flow; or app-only client credentials
  * (set tenantId/clientId/clientSecret + userUpn) for an unattended service
  * mailbox. Shared "microsoft" OAuth client family (authUrl on
  * login.microsoftonline.com), so one Entra app is reused across the Microsoft

--- a/packages/runline-plugins/microsoftMail/src/index.ts
+++ b/packages/runline-plugins/microsoftMail/src/index.ts
@@ -43,6 +43,7 @@ export default function microsoftMail(rl: RunlinePluginAPI): void {
     tenantId: { type: "string", required: false, env: "MS_GRAPH_TENANT_ID", description: "Entra tenant id (app-only) or omit for OAuth /common" },
     clientId: { type: "string", required: false, env: "MS_GRAPH_CLIENT_ID", description: "App (client) id" },
     clientSecret: { type: "string", required: false, env: "MS_GRAPH_CLIENT_SECRET", description: "Client secret VALUE" },
+    refreshToken: { type: "string", required: false, env: "MICROSOFTMAIL_REFRESH_TOKEN", description: "OAuth2 refresh token (set by the login flow)" },
     userUpn: { type: "string", required: false, env: "MS_GRAPH_USER_UPN", description: "App-only only: target mailbox UPN (e.g. agent@contoso.com)" },
   });
 

--- a/packages/runline-plugins/microsoftMail/src/index.ts
+++ b/packages/runline-plugins/microsoftMail/src/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Microsoft Outlook mail plugin for runline (Microsoft Graph).
+ *
+ * Auth: Microsoft identity platform OAuth2 (delegated, acts as the signed-in
+ * user → /me) seeded by Vex's OAuth wizard; or app-only client credentials
+ * (set tenantId/clientId/clientSecret + userUpn) for an unattended service
+ * mailbox. Shared "microsoft" OAuth client family (authUrl on
+ * login.microsoftonline.com), so one Entra app is reused across the Microsoft
+ * plugins. See _shared/microsoftAuth.ts.
+ *
+ * Graph delegated scopes: Mail.Send, Mail.ReadWrite, Mail.Read.
+ */
+import type { ActionContext, RunlinePluginAPI } from "runline";
+import { graphRequest, microsoftSetupHelp, userBase } from "../../_shared/microsoftAuth.js";
+
+const NAME = "microsoftMail";
+const SCOPES = [
+  "https://graph.microsoft.com/Mail.Send",
+  "https://graph.microsoft.com/Mail.ReadWrite",
+  "https://graph.microsoft.com/Mail.Read",
+];
+
+type Ctx = ActionContext;
+const recipients = (addrs: string[] | string | undefined) =>
+  (Array.isArray(addrs) ? addrs : addrs ? [addrs] : []).map((a) => ({
+    emailAddress: { address: a },
+  }));
+
+function toMessage(input: any) {
+  return {
+    subject: input.subject,
+    body: { contentType: input.html ? "HTML" : "Text", content: input.body ?? "" },
+    toRecipients: recipients(input.to),
+    ccRecipients: recipients(input.cc),
+  };
+}
+
+export default function microsoftMail(rl: RunlinePluginAPI): void {
+  rl.setName(NAME);
+  rl.setVersion("1.0.0");
+
+  rl.setConnectionSchema({
+    tenantId: { type: "string", required: false, env: "MS_GRAPH_TENANT_ID", description: "Entra tenant id (app-only) or omit for OAuth /common" },
+    clientId: { type: "string", required: false, env: "MS_GRAPH_CLIENT_ID", description: "App (client) id" },
+    clientSecret: { type: "string", required: false, env: "MS_GRAPH_CLIENT_SECRET", description: "Client secret VALUE" },
+    userUpn: { type: "string", required: false, env: "MS_GRAPH_USER_UPN", description: "App-only only: target mailbox UPN (e.g. agent@contoso.com)" },
+  });
+
+  rl.setOAuth({
+    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    scopes: [...SCOPES, "offline_access"],
+    authParams: { prompt: "consent" },
+    setupHelp: microsoftSetupHelp("Mail.Send, Mail.ReadWrite, Mail.Read"),
+  });
+
+  rl.registerAction("mail.send", {
+    description:
+      "Send an email as the connected mailbox. Returns {success}. Get user approval before sending external mail.",
+    inputSchema: {
+      to: { type: "array", required: true, description: "Recipient address(es)" },
+      subject: { type: "string", required: true },
+      body: { type: "string", required: true },
+      cc: { type: "array", required: false },
+      html: { type: "boolean", required: false, description: "Body is HTML (default plain text)" },
+    },
+    async execute(input: any, ctx: Ctx) {
+      await graphRequest(ctx, NAME, SCOPES, "POST", `${userBase(ctx)}/sendMail`, {
+        message: toMessage(input),
+        saveToSentItems: true,
+      });
+      return { success: true };
+    },
+  });
+
+  rl.registerAction("mail.draft", {
+    description: "Create a draft email (not sent). Returns {id, webLink}.",
+    inputSchema: {
+      to: { type: "array", required: false },
+      subject: { type: "string", required: true },
+      body: { type: "string", required: true },
+      cc: { type: "array", required: false },
+      html: { type: "boolean", required: false },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const r = await graphRequest(ctx, NAME, SCOPES, "POST", `${userBase(ctx)}/messages`, toMessage(input));
+      return { id: r.id, webLink: r.webLink };
+    },
+  });
+
+  rl.registerAction("mail.list", {
+    description:
+      "List recent messages. Optional KQL search. Returns [{id,subject,from,receivedDateTime,bodyPreview,hasAttachments}].",
+    inputSchema: {
+      search: { type: "string", required: false, description: "KQL search across the mailbox" },
+      top: { type: "number", required: false, default: 20 },
+    },
+    async execute(input: any, ctx: Ctx) {
+      const qs = new URLSearchParams({
+        $top: String(input.top ?? 20),
+        $select: "id,subject,from,receivedDateTime,bodyPreview,hasAttachments",
+        $orderby: "receivedDateTime desc",
+      });
+      if (input.search) qs.set("$search", `"${input.search}"`);
+      const r = await graphRequest(ctx, NAME, SCOPES, "GET", `${userBase(ctx)}/messages?${qs}`);
+      return r.value;
+    },
+  });
+
+  rl.registerAction("mail.get", {
+    description: "Get one message with full body by id.",
+    inputSchema: { id: { type: "string", required: true } },
+    async execute(input: any, ctx: Ctx) {
+      return graphRequest(ctx, NAME, SCOPES, "GET", `${userBase(ctx)}/messages/${input.id}`);
+    },
+  });
+}

--- a/packages/runline-plugins/microsoftMail/src/index.ts
+++ b/packages/runline-plugins/microsoftMail/src/index.ts
@@ -51,7 +51,6 @@ export default function microsoftMail(rl: RunlinePluginAPI): void {
     authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     scopes: [...SCOPES, "offline_access"],
-    authParams: { prompt: "consent" },
     setupHelp: microsoftSetupHelp("Mail.Send, Mail.ReadWrite, Mail.Read"),
   });
 


### PR DESCRIPTION
## What

Three bundled plugins for **Microsoft 365 via Microsoft Graph**, mirroring the existing Google plugin family:

| Plugin | Actions |
|---|---|
| `microsoftMail` | `mail.send`, `mail.draft`, `mail.list`, `mail.get` |
| `microsoftCalendar` | `calendar.list`, `event.get` |
| `microsoftFiles` | `files.search`, `files.list`, `files.get` (download), `files.upload`, `folder.create` (OneDrive/SharePoint) |

## Auth

New `_shared/microsoftAuth.ts` provides **dual-mode** auth, auto-detected from the connection config:

- **Delegated OAuth2** — acts as the signed-in user (`/me`), seeded by the OAuth wizard. All three share one **`microsoft` OAuth client family** (`authUrl` on `login.microsoftonline.com`), so one Entra app is reused across the plugins (same shared-family mechanism as Google).
- **App-only client credentials** — set `tenantId`/`clientId`/`clientSecret` + `userUpn` (`/users/{upn}`) for unattended service accounts.

Access tokens are cached on the connection (`accessToken`/`accessTokenExpiresAt`) and rotated refresh tokens are persisted via `ctx.updateConnection`, matching the Google plugins' pattern. Connection fields carry `env` hints (`MS_GRAPH_*`).

## Notes

- Auto-discovered by the plugin loader's directory scan — no manifest/registry change needed.
- Structured to match the bundled-plugin conventions (`.js` import specifiers, `setOAuth`/`setConnectionSchema`/`registerAction`).
- Graph delegated scopes: `Mail.Send`/`Mail.ReadWrite`/`Mail.Read`, `Calendars.Read`, `Files.ReadWrite.All`/`Sites.ReadWrite.All`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)