### PR TITLE
openai: configurable default image model + write images to file

### DIFF
--- a/packages/runline-plugins/openai/src/index.ts
+++ b/packages/runline-plugins/openai/src/index.ts
@@ -1,24 +1,23 @@
 /**
  * OpenAI image generation for runline.
  *
- * Wraps the GPT Image / DALL-E line at /v1/images/generations and
- * returns base64 bytes alongside the (optional) revised prompt the
- * model wrote for itself.
+ * Wraps the GPT Image / DALL-E line at /v1/images/generations. Generated
+ * images are written to disk and the action returns their file `path`s
+ * (plus the optional revised prompt) — never raw base64, which bloats the
+ * agent context and is stripped before delivery. Hand each `path` to the
+ * host's file-sending tool (e.g. send_file) to deliver the image.
  *
  * Quality leader for text rendering and prompt adherence — pair with
  * any other plugin you'd compose images for (storyblok, github,
  * notion, slack uploads, …).
  *
- *   await openai.image.create({ prompt: "a red bicycle on snow" })
- *   await openai.image.create({
- *     prompt: "logo for a coffee shop",
- *     model: "dall-e-3",
- *     style: "vivid",
- *     quality: "high",
- *     size: "1024x1024",
- *   })
+ *   const { images } = await openai.image.create({ prompt: "a red bicycle on snow" })
+ *   // images[0].path -> "/tmp/openai-image-….png"
  */
 
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { RunlinePluginAPI } from "runline";
 
 const ENDPOINT = "https://api.openai.com/v1/images/generations";
@@ -30,6 +29,7 @@ interface CreateInput {
   quality?: string;
   style?: string;
   n?: number;
+  saveDir?: string;
 }
 
 interface OpenAIImage {
@@ -59,12 +59,17 @@ export default function openai(rl: RunlinePluginAPI) {
 
   rl.registerAction("image.create", {
     description:
-      "Generate an image with OpenAI (GPT Image / DALL-E). Returns base64-encoded PNGs and any revised prompt the model produced.",
+      "Generate an image with OpenAI (GPT Image / DALL-E). Writes the PNG(s) to disk and returns their file `path`s (plus any revised prompt) — not base64. Deliver each image to the user with send_file using its `path`.",
     inputSchema: {
       prompt: {
         type: "string",
         required: true,
         description: "Detailed description of the image",
+      },
+      saveDir: {
+        type: "string",
+        required: false,
+        description: "Directory to write the image file(s) into. Defaults to the OS temp dir.",
       },
       model: {
         type: "string",
@@ -135,12 +140,25 @@ export default function openai(rl: RunlinePluginAPI) {
       }
 
       const data = (await res.json()) as { data?: OpenAIImage[] };
-      const images = (data.data ?? []).map((d) => ({
-        base64: d.b64_json,
-        mimeType: "image/png",
-        ...(d.revised_prompt ? { revisedPrompt: d.revised_prompt } : {}),
-      }));
-      return { provider: "openai", model, images };
+      const dir = (typeof p.saveDir === "string" && p.saveDir.trim()) || tmpdir();
+      const stamp = Date.now();
+      const images = (data.data ?? []).map((d, i) => {
+        const bytes = Buffer.from(d.b64_json ?? "", "base64");
+        const path = join(dir, `openai-image-${stamp}-${i}.png`);
+        writeFileSync(path, bytes);
+        return {
+          path,
+          mimeType: "image/png",
+          byteLength: bytes.length,
+          ...(d.revised_prompt ? { revisedPrompt: d.revised_prompt } : {}),
+        };
+      });
+      return {
+        provider: "openai",
+        model,
+        images,
+        note: "Image(s) written to disk. Deliver each to the user with send_file using its `path`.",
+      };
     },
   });
 }

--- a/packages/runline-plugins/openai/src/index.ts
+++ b/packages/runline-plugins/openai/src/index.ts
@@ -48,6 +48,13 @@ export default function openai(rl: RunlinePluginAPI) {
       description: "OpenAI API key",
       env: "OPENAI_API_KEY",
     },
+    defaultModel: {
+      type: "string",
+      required: false,
+      description:
+        "Default image model when a call omits `model` (e.g. gpt-image-2). Falls back to gpt-image-1.",
+      env: "OPENAI_IMAGE_MODEL",
+    },
   });
 
   rl.registerAction("image.create", {
@@ -63,7 +70,7 @@ export default function openai(rl: RunlinePluginAPI) {
         type: "string",
         required: false,
         description:
-          "gpt-image-1 (default) | gpt-image-1-mini | dall-e-3 | dall-e-2",
+          "gpt-image-2 | gpt-image-1 | gpt-image-1-mini | dall-e-3 | dall-e-2. Omit to use the connection default.",
       },
       size: {
         type: "string",
@@ -94,7 +101,10 @@ export default function openai(rl: RunlinePluginAPI) {
       }
 
       const apiKey = ctx.connection.config.apiKey as string;
-      const model = p.model ?? "gpt-image-1";
+      const model =
+        p.model ??
+        (ctx.connection.config.defaultModel as string | undefined) ??
+        "gpt-image-1";
 
       const body: Record<string, unknown> = {
         model,


### PR DESCRIPTION
Two changes that make the `openai` image plugin usable in production from a chat agent:

## 1. Configurable default image model
Adds an optional `defaultModel` connection field (env `OPENAI_IMAGE_MODEL`) so a deployment can set the default model used when a call omits `model` (e.g. `gpt-image-2`). Precedence: per-call `model` → `OPENAI_IMAGE_MODEL` → `gpt-image-1`. Non-breaking.

## 2. Write images to disk instead of returning base64
`image.create` now writes each generated PNG to disk (an optional `saveDir`, else the OS temp dir) and returns its file `path` + `byteLength` (plus any revised prompt) — **not** raw base64.

Why: base64 image payloads in an action result blow up the agent's context (and many hosts strip large base64 before it reaches the model), so the agent could never actually deliver the image. A file `path` hands straight to a host `send_file`/attachment tool.

Matches the file-path pattern already used by `googleSlides`/`googleDrive`. Uses `node:fs`/`node:os`/`node:path` (plugins load in-process via jiti, like the other fs-using plugins).