### PR TITLE
Fix Gmail base64url attachment encoding

### DIFF
--- a/packages/runline-plugins/gmail/src/index.ts
+++ b/packages/runline-plugins/gmail/src/index.ts
@@ -178,6 +178,24 @@ function foldedBase64ByteLength(length: number): number {
   return length === 0 ? 0 : length + Math.floor((length - 1) / 76) * CRLF.length;
 }
 
+function normalizeMimeBase64(value: string, index: number): string {
+  const compact = value.replace(/\s+/g, "");
+  if (!/^[A-Za-z0-9+/=_-]*$/.test(compact)) {
+    throw new Error(
+      `gmail: attachment ${index} contentBase64 contains invalid base64 characters`,
+    );
+  }
+
+  const standard = compact.replace(/-/g, "+").replace(/_/g, "/");
+  const remainder = standard.length % 4;
+  if (remainder === 1) {
+    throw new Error(
+      `gmail: attachment ${index} contentBase64 has invalid base64 length`,
+    );
+  }
+  return remainder === 0 ? standard : `${standard}${"=".repeat(4 - remainder)}`;
+}
+
 function foldBase64(encoded: string): string {
   let folded = "";
   for (let i = 0; i < encoded.length; i += 76) {
@@ -235,7 +253,7 @@ function normalizeAttachment(
   return {
     name: input.name ?? input.filename ?? `attachment-${index + 1}`,
     mimeType: input.mimeType ?? "application/octet-stream",
-    contentBase64,
+    contentBase64: normalizeMimeBase64(contentBase64, index),
   };
 }
 

--- a/packages/runline/src/tests/gmail-plugin.test.ts
+++ b/packages/runline/src/tests/gmail-plugin.test.ts
@@ -69,6 +69,45 @@ describe("gmail plugin MIME encoding", () => {
     assert.ok(raw.length > 0);
   });
 
+  it("normalizes base64url attachment content into MIME-safe base64", () => {
+    const bytes = Buffer.from([251, 255, 254, 250, 239, 190]);
+    const raw = encodeEmail({
+      to: "recipient@example.com",
+      subject: "gmail attachment",
+      text: "see attached",
+      attachments: [
+        {
+          name: "gmail.bin",
+          mimeType: "application/octet-stream",
+          contentBase64: bytes.toString("base64url"),
+        },
+      ],
+    });
+
+    const message = Buffer.from(raw, "base64url").toString("utf8");
+    assert.match(message, /Content-Transfer-Encoding: base64/);
+    assert.match(message, /\+\/\/\+\+u\+\+/);
+    assert.doesNotMatch(message, /-__\-/);
+  });
+
+  it("throws a clear error for invalid attachment base64 characters", () => {
+    assert.throws(
+      () =>
+        encodeEmail({
+          to: "recipient@example.com",
+          subject: "bad attachment",
+          attachments: [
+            {
+              name: "bad.txt",
+              mimeType: "text/plain",
+              contentBase64: "not base64!",
+            },
+          ],
+        }),
+      /gmail: attachment 0 contentBase64 contains invalid base64 characters/,
+    );
+  });
+
   it("throws a clear error for invalid attachment content", () => {
     assert.throws(
       () =>


### PR DESCRIPTION
## Summary
- Normalize Gmail attachment `contentBase64` from base64url/whitespace-tolerant input into MIME-safe base64.
- Reject invalid attachment base64 characters/length with clear Gmail plugin errors.
- Add regression coverage for Gmail/Drive-shaped attachment payloads.

## Tests
- `bun test packages/runline/src/tests/gmail-plugin.test.ts`
- `HOME=$(mktemp -d) bun test` — 109 passed, 0 failed
