### PR TITLE
Support TypeBox input schemas for actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/pi-runline": {
       "name": "pi-runline",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "dependencies": {
         "runline": "^0.2.2",
       },
@@ -23,7 +23,7 @@
     },
     "packages/runline": {
       "name": "runline",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "bin": {
         "runline": "./dist/main.js",
       },
@@ -34,6 +34,7 @@
         "proper-lockfile": "^4.1.2",
         "quickjs-emscripten": "^0.32.0",
         "rrule": "^2.8.1",
+        "typebox": "^1.1.35",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -573,6 +574,8 @@
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typebox": ["typebox@1.1.39", "", {}, "sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/packages/runline/package.json
+++ b/packages/runline/package.json
@@ -68,6 +68,7 @@
     "jiti": "^2.7.0",
     "proper-lockfile": "^4.1.2",
     "quickjs-emscripten": "^0.32.0",
-    "rrule": "^2.8.1"
+    "rrule": "^2.8.1",
+    "typebox": "^1.1.35"
   }
 }

--- a/packages/runline/src/core/engine.ts
+++ b/packages/runline/src/core/engine.ts
@@ -10,9 +10,16 @@ import {
 import { applyEnvOverrides, updateConnectionConfig } from "../config/loader.js";
 import type { RunlineConfig } from "../config/types.js";
 import type { PluginRegistry } from "../plugin/registry.js";
+import {
+  formatValidationError,
+  helpInputs,
+  isTypedInputSchema,
+  validateTypedInput,
+} from "../plugin/schema.js";
 import type {
   ActionContext,
   ConnectionConfig,
+  HelpInput,
   PluginDef,
 } from "../plugin/types.js";
 
@@ -205,6 +212,13 @@ export class ExecutionEngine {
       },
     };
 
+    if (isTypedInputSchema(action.inputSchema)) {
+      const validation = validateTypedInput(action.inputSchema, args);
+      if (!validation.ok) {
+        throw new Error(formatValidationError(path, validation));
+      }
+    }
+
     return action.execute(args, ctx);
   }
 
@@ -315,12 +329,6 @@ const __minisearchSource = readFileSync(
   "utf8",
 );
 
-interface HelpInput {
-  type: string;
-  required: boolean;
-  description?: string;
-}
-
 interface HelpEntry {
   action: string;
   description?: string;
@@ -333,16 +341,7 @@ function buildHelpData(plugins: PluginDef[]): Record<string, HelpEntry[]> {
     data[p.name] = p.actions.map((a) => ({
       action: a.name,
       description: a.description,
-      inputs: Object.fromEntries(
-        Object.entries(a.inputSchema ?? {}).map(([k, v]) => [
-          k,
-          {
-            type: v.type,
-            required: !!v.required,
-            description: v.description,
-          },
-        ]),
-      ),
+      inputs: helpInputs(a.inputSchema),
     }));
   }
   return data;
@@ -404,7 +403,7 @@ const __index = (() => {
 
 const __formatSignature = (plugin, entry) => {
   const fields = Object.entries(entry.inputs || {})
-    .map(([k, v]) => k + (v.required ? '' : '?') + ': ' + v.type)
+    .map(([k, v]) => k + (v.required ? '' : '?') + ': ' + (v.displayType || v.type))
     .join(', ');
   return plugin + '.' + entry.action + (fields ? '({ ' + fields + ' })' : '()');
 };
@@ -483,10 +482,15 @@ const __actionsApi = {
     for (const k of Object.keys(provided)) {
       if (!(k in inputs)) unknown.push(k);
       else {
-        const expected = inputs[k].type;
-        const actual = Array.isArray(provided[k]) ? 'array' : typeof provided[k];
-        if (expected !== actual && !(provided[k] === null || provided[k] === undefined)) {
-          typeErrors.push({ field: k, expected, actual });
+        const spec = inputs[k];
+        const expected = spec.type;
+        const actual = Array.isArray(provided[k]) ? 'array' : provided[k] === null ? 'null' : typeof provided[k];
+        if (provided[k] !== null && provided[k] !== undefined && expected !== actual) {
+          typeErrors.push({ field: k, expected: spec.displayType || expected, actual });
+        } else if (spec.enum && !spec.enum.includes(provided[k])) {
+          typeErrors.push({ field: k, expected: spec.enum.map(String).join(' | '), actual: __fmt(provided[k]) });
+        } else if ('const' in spec && provided[k] !== spec.const) {
+          typeErrors.push({ field: k, expected: __fmt(spec.const), actual: __fmt(provided[k]) });
         }
       }
     }

--- a/packages/runline/src/plugin/schema.ts
+++ b/packages/runline/src/plugin/schema.ts
@@ -1,0 +1,193 @@
+import { Check, Errors } from "typebox/value";
+import type {
+  HelpInput,
+  InputSchema,
+  LegacyInputSchema,
+  TypedInputSchema,
+} from "./types.js";
+
+export interface ValidationResult {
+  ok: boolean;
+  missing: string[];
+  unknown: string[];
+  typeErrors: Array<{ field: string; expected: string; actual: string }>;
+  errors: string[];
+}
+
+export function isTypedInputSchema(
+  schema: InputSchema | undefined,
+): schema is TypedInputSchema {
+  if (!schema || typeof schema !== "object") return false;
+  const candidate = schema as TypedInputSchema;
+  return typeof candidate.type === "string" || Array.isArray(candidate.anyOf);
+}
+
+export function legacyFields(
+  schema: InputSchema | undefined,
+): LegacyInputSchema {
+  if (!schema || isTypedInputSchema(schema)) return {};
+  return schema;
+}
+
+export function helpInputs(
+  schema: InputSchema | undefined,
+): Record<string, HelpInput> {
+  if (!schema) return {};
+  if (!isTypedInputSchema(schema)) {
+    return Object.fromEntries(
+      Object.entries(schema).map(([key, field]) => [
+        key,
+        {
+          type: field.type,
+          required: !!field.required,
+          description: field.description,
+        },
+      ]),
+    );
+  }
+
+  if (schema.type !== "object") return {};
+  const required = new Set(schema.required ?? []);
+  return Object.fromEntries(
+    Object.entries(schema.properties ?? {}).map(([key, field]) => [
+      key,
+      {
+        type: baseType(field),
+        displayType: displayType(field),
+        required: required.has(key),
+        description: field.description,
+        enum: enumValues(field),
+        const: field.const,
+      },
+    ]),
+  );
+}
+
+export function validateLegacyInput(
+  schema: LegacyInputSchema,
+  input: unknown,
+): ValidationResult {
+  const provided =
+    input && typeof input === "object"
+      ? (input as Record<string, unknown>)
+      : {};
+  const missing: string[] = [];
+  const unknown: string[] = [];
+  const typeErrors: ValidationResult["typeErrors"] = [];
+
+  for (const [key, spec] of Object.entries(schema)) {
+    if (spec.required && !(key in provided)) missing.push(key);
+  }
+  for (const key of Object.keys(provided)) {
+    if (!(key in schema)) {
+      unknown.push(key);
+      continue;
+    }
+    const expected = schema[key].type;
+    const actual = valueType(provided[key]);
+    if (
+      provided[key] !== null &&
+      provided[key] !== undefined &&
+      expected !== actual
+    ) {
+      typeErrors.push({ field: key, expected, actual });
+    }
+  }
+
+  return validationResult({ missing, unknown, typeErrors });
+}
+
+export function validateTypedInput(
+  schema: TypedInputSchema,
+  input: unknown,
+): ValidationResult {
+  if (Check(schema, input)) return validationResult({});
+
+  return validationResult({
+    errors: [...Errors(schema, input)].map((error) => {
+      const path = error.instancePath || "/";
+      return `${path} ${error.message}`;
+    }),
+  });
+}
+
+export function formatValidationError(
+  path: string,
+  result: ValidationResult,
+): string {
+  const parts = [`Invalid input for ${path}.`];
+  if (result.missing.length > 0) {
+    parts.push(`Missing required fields: ${result.missing.join(", ")}.`);
+  }
+  if (result.unknown.length > 0) {
+    parts.push(`Unknown fields: ${result.unknown.join(", ")}.`);
+  }
+  if (result.typeErrors.length > 0) {
+    parts.push(
+      `Type errors: ${result.typeErrors
+        .map((e) => `${e.field} expected ${e.expected}, got ${e.actual}`)
+        .join("; ")}.`,
+    );
+  }
+  if (result.errors.length > 0) {
+    parts.push(`Validation errors: ${result.errors.join("; ")}.`);
+  }
+  return parts.join(" ");
+}
+
+function validationResult(input: {
+  missing?: string[];
+  unknown?: string[];
+  typeErrors?: ValidationResult["typeErrors"];
+  errors?: string[];
+}): ValidationResult {
+  const missing = input.missing ?? [];
+  const unknown = input.unknown ?? [];
+  const typeErrors = input.typeErrors ?? [];
+  const errors = input.errors ?? [];
+  return {
+    ok:
+      missing.length === 0 &&
+      unknown.length === 0 &&
+      typeErrors.length === 0 &&
+      errors.length === 0,
+    missing,
+    unknown,
+    typeErrors,
+    errors,
+  };
+}
+
+function displayType(schema: TypedInputSchema): string {
+  if (schema.anyOf?.length) return schema.anyOf.map(displayType).join(" | ");
+  if (schema.enum?.length) return schema.enum.map(String).join(" | ");
+  if (schema.const !== undefined) return JSON.stringify(schema.const);
+  return schema.type ?? "unknown";
+}
+
+function baseType(schema: TypedInputSchema): string {
+  if (schema.anyOf?.length) {
+    const types = [...new Set(schema.anyOf.map(baseType))];
+    return types.length === 1 ? types[0] : types.join(" | ");
+  }
+  if (schema.type) return schema.type;
+  if (schema.const !== undefined) return valueType(schema.const);
+  return "unknown";
+}
+
+function enumValues(schema: TypedInputSchema): unknown[] | undefined {
+  if (schema.enum?.length) return schema.enum;
+  if (
+    schema.anyOf?.length &&
+    schema.anyOf.every((s) => s.const !== undefined)
+  ) {
+    return schema.anyOf.map((s) => s.const);
+  }
+  return undefined;
+}
+
+function valueType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}

--- a/packages/runline/src/plugin/schema.ts
+++ b/packages/runline/src/plugin/schema.ts
@@ -6,6 +6,16 @@ import type {
   TypedInputSchema,
 } from "./types.js";
 
+interface SchemaMetadata {
+  type?: string;
+  properties?: Record<string, SchemaMetadata>;
+  required?: string[];
+  anyOf?: SchemaMetadata[];
+  enum?: unknown[];
+  const?: unknown;
+  description?: string;
+}
+
 export interface ValidationResult {
   ok: boolean;
   missing: string[];
@@ -18,7 +28,7 @@ export function isTypedInputSchema(
   schema: InputSchema | undefined,
 ): schema is TypedInputSchema {
   if (!schema || typeof schema !== "object") return false;
-  const candidate = schema as TypedInputSchema;
+  const candidate = schema as SchemaMetadata;
   return typeof candidate.type === "string" || Array.isArray(candidate.anyOf);
 }
 
@@ -34,8 +44,9 @@ export function helpInputs(
 ): Record<string, HelpInput> {
   if (!schema) return {};
   if (!isTypedInputSchema(schema)) {
+    const legacy = schema as LegacyInputSchema;
     return Object.fromEntries(
-      Object.entries(schema).map(([key, field]) => [
+      Object.entries(legacy).map(([key, field]) => [
         key,
         {
           type: field.type,
@@ -46,10 +57,11 @@ export function helpInputs(
     );
   }
 
-  if (schema.type !== "object") return {};
-  const required = new Set(schema.required ?? []);
+  const metadata = schema as SchemaMetadata;
+  if (metadata.type !== "object") return {};
+  const required = new Set(metadata.required ?? []);
   return Object.fromEntries(
-    Object.entries(schema.properties ?? {}).map(([key, field]) => [
+    Object.entries(metadata.properties ?? {}).map(([key, field]) => [
       key,
       {
         type: baseType(field),
@@ -158,14 +170,14 @@ function validationResult(input: {
   };
 }
 
-function displayType(schema: TypedInputSchema): string {
+function displayType(schema: SchemaMetadata): string {
   if (schema.anyOf?.length) return schema.anyOf.map(displayType).join(" | ");
   if (schema.enum?.length) return schema.enum.map(String).join(" | ");
   if (schema.const !== undefined) return JSON.stringify(schema.const);
   return schema.type ?? "unknown";
 }
 
-function baseType(schema: TypedInputSchema): string {
+function baseType(schema: SchemaMetadata): string {
   if (schema.anyOf?.length) {
     const types = [...new Set(schema.anyOf.map(baseType))];
     return types.length === 1 ? types[0] : types.join(" | ");
@@ -175,7 +187,7 @@ function baseType(schema: TypedInputSchema): string {
   return "unknown";
 }
 
-function enumValues(schema: TypedInputSchema): unknown[] | undefined {
+function enumValues(schema: SchemaMetadata): unknown[] | undefined {
   if (schema.enum?.length) return schema.enum;
   if (
     schema.anyOf?.length &&

--- a/packages/runline/src/plugin/types.ts
+++ b/packages/runline/src/plugin/types.ts
@@ -1,3 +1,5 @@
+import type { TSchema } from "typebox";
+
 export interface InputField {
   type: "string" | "number" | "boolean" | "object" | "array";
   description?: string;
@@ -5,7 +7,18 @@ export interface InputField {
   default?: unknown;
 }
 
-export type InputSchema = Record<string, InputField>;
+export type LegacyInputSchema = Record<string, InputField>;
+export type TypedInputSchema = TSchema;
+export type InputSchema = LegacyInputSchema | TypedInputSchema;
+
+export interface HelpInput {
+  type: string;
+  displayType?: string;
+  required: boolean;
+  description?: string;
+  enum?: unknown[];
+  const?: unknown;
+}
 
 export interface ActionDef {
   name: string;

--- a/packages/runline/src/tests/actions-api.test.ts
+++ b/packages/runline/src/tests/actions-api.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import {
+  Literal,
+  Optional,
+  Boolean as TBoolean,
+  Object as TObject,
+  Union,
+} from "typebox";
 import { DEFAULT_CONFIG } from "../config/types.js";
 import { ExecutionEngine } from "../core/engine.js";
 import { createPluginAPI } from "../plugin/api.js";
@@ -32,6 +39,17 @@ function makeGithub() {
     description: "List repos for a user",
     inputSchema: { username: { type: "string", required: true } },
     execute: async () => [],
+  });
+  api.registerAction("settings.update", {
+    description: "Update typed settings",
+    inputSchema: TObject(
+      {
+        mode: Union([Literal("safe"), Literal("loud")]),
+        enabled: Optional(TBoolean()),
+      },
+      { additionalProperties: false },
+    ),
+    execute: async (input) => input,
   });
   return resolve();
 }
@@ -81,6 +99,7 @@ describe("actions.list", () => {
       [
         "github.issue.create",
         "github.issue.list",
+        "github.settings.update",
         "github.user.listRepos",
         "pipedrive.deal.list",
         "plain.ping",
@@ -93,6 +112,7 @@ describe("actions.list", () => {
     assert.deepEqual([...result].sort(), [
       "github.issue.create",
       "github.issue.list",
+      "github.settings.update",
       "github.user.listRepos",
     ]);
   });
@@ -185,6 +205,17 @@ describe("actions.describe", () => {
     assert.deepEqual(result.inputs, {});
   });
 
+  it("summarizes TypeBox input schemas", async () => {
+    const result = await run<{
+      signature: string;
+      inputs: Record<string, { type: string; required: boolean }>;
+    }>('return actions.describe("github.settings.update")');
+    assert.match(result.signature, /mode: "safe" \| "loud"/);
+    assert.match(result.signature, /enabled\?: boolean/);
+    assert.equal(result.inputs.mode.required, true);
+    assert.equal(result.inputs.enabled.required, false);
+  });
+
   it("throws with did-you-mean suggestions on unknown path", async () => {
     const code = `try { actions.describe("github.issue.craete"); return null; } catch (e) { return e.message; }`;
     const msg = await run<string>(code);
@@ -238,6 +269,22 @@ describe("actions.check", () => {
     assert.equal(result.ok, true);
   });
 
+  it("checks literal union values for TypeBox input schemas", async () => {
+    const valid = await run<{ ok: boolean }>(
+      `return actions.check("github.settings.update", { mode: "safe", enabled: true })`,
+    );
+    assert.equal(valid.ok, true);
+
+    const invalid = await run<{
+      ok: boolean;
+      typeErrors: Array<{ field: string; expected: string; actual: string }>;
+    }>(`return actions.check("github.settings.update", { mode: "danger" })`);
+    assert.equal(invalid.ok, false);
+    assert.deepEqual(invalid.typeErrors, [
+      { field: "mode", expected: "safe | loud", actual: "danger" },
+    ]);
+  });
+
   it("returns suggestions for unknown action", async () => {
     const result = await run<{
       ok: boolean;
@@ -275,6 +322,6 @@ describe("actions proxy fallback", () => {
     const result = await run<unknown>(
       `const list = actions.list("github"); const r = await github.issue.list({ owner: "a", repo: "b" }); return { count: list.length, r };`,
     );
-    assert.deepEqual(result, { count: 3, r: [] });
+    assert.deepEqual(result, { count: 4, r: [] });
   });
 });

--- a/packages/runline/src/tests/engine.test.ts
+++ b/packages/runline/src/tests/engine.test.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import {
+  Literal,
+  Array as TArray,
+  Boolean as TBoolean,
+  Number as TNumber,
+  Object as TObject,
+  String as TString,
+  Union,
+} from "typebox";
 import { DEFAULT_CONFIG } from "../config/types.js";
 import { ExecutionEngine } from "../core/engine.js";
 import { createPluginAPI } from "../plugin/api.js";
@@ -24,6 +33,39 @@ function makeTestPlugin() {
 
   api.registerAction("echo", {
     description: "Echo input back",
+    execute(input) {
+      return input;
+    },
+  });
+
+  api.registerAction("typed", {
+    description: "Action with a TypeBox input schema",
+    inputSchema: TObject(
+      {
+        mode: Union([Literal("safe"), Literal("loud")]),
+        enabled: TBoolean(),
+        label: TString({ minLength: 2, maxLength: 5 }),
+        amount: TNumber({ minimum: 1, maximum: 10 }),
+        tags: TArray(TString()),
+        nested: TObject(
+          {
+            count: TNumber(),
+          },
+          { additionalProperties: false },
+        ),
+      },
+      { additionalProperties: false },
+    ),
+    execute(input) {
+      return input;
+    },
+  });
+
+  api.registerAction("legacyTypeField", {
+    description: "Legacy schema with a field named type",
+    inputSchema: {
+      type: { type: "string", required: true },
+    },
     execute(input) {
       return input;
     },
@@ -126,6 +168,55 @@ describe("ExecutionEngine", () => {
     );
     assert.equal(result.error, undefined);
     assert.deepEqual(result.result, { waited: 10 });
+  });
+
+  it("validates TypeBox input schemas before executing", async () => {
+    const engine = createEngine();
+    const result = await engine.execute(
+      `return await math.typed({ mode: "safe", enabled: true, label: "abc", amount: 5, tags: ["ok"], nested: { count: 2 } })`,
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.result, {
+      mode: "safe",
+      enabled: true,
+      label: "abc",
+      amount: 5,
+      tags: ["ok"],
+      nested: { count: 2 },
+    });
+  });
+
+  it("rejects invalid TypeBox inputs before executing", async () => {
+    const engine = createEngine();
+    const result = await engine.execute(
+      `return await math.typed({ mode: "danger", enabled: "yes", label: "abcdef", amount: 11, extra: true, nested: { nope: 1 } })`,
+    );
+    assert.ok(result.error);
+    assert.match(result.error, /Invalid input for math\.typed/);
+    assert.match(result.error, /Validation errors:/);
+    assert.match(result.error, /must not have additional properties/);
+    assert.match(result.error, /\/mode must match a schema in anyOf/);
+    assert.match(result.error, /\/enabled must be boolean/);
+    assert.match(result.error, /\/label must not have more than 5 characters/);
+    assert.match(result.error, /\/amount must be <= 10/);
+  });
+
+  it("does not confuse a legacy field named type for a TypeBox schema", async () => {
+    const engine = createEngine();
+    const result = await engine.execute(
+      `return await math.legacyTypeField({ type: 123, extra: true })`,
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.result, { type: 123, extra: true });
+  });
+
+  it("keeps legacy input schemas metadata-only at execution time", async () => {
+    const engine = createEngine();
+    const result = await engine.execute(
+      `return await math.add({ a: "loose", b: 2, extra: true })`,
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.result, { sum: "loose2" });
   });
 
   it("executes plain JS with variables", async () => {


### PR DESCRIPTION
Closes #17.

Adds first-class TypeBox input-schema support for Runline actions.

Changes:
- Accept TypeBox schemas as action `inputSchema` values
- Validate TypeBox inputs before action execution using `typebox/value`
- Preserve legacy field-map schemas as metadata-only for compatibility
- Add shared schema helpers for validation and action help metadata
- Keep `actions.describe` and `actions.check` useful for TypeBox-backed actions

Verification:
- `bun --filter runline check`
- `bun --filter runline test`