### PR TITLE
Add Linear comment create action

### DIFF
--- a/packages/runline-plugins/linear/src/index.ts
+++ b/packages/runline-plugins/linear/src/index.ts
@@ -127,6 +127,14 @@ const LIST_INPUT_SCHEMA = {
   before: { type: "string", required: false, description: "Cursor for backward pagination" },
 } as const;
 
+const COMMENT_CREATE_INPUT_SCHEMA = {
+  issueId: { type: "string", required: true, description: "The issue to associate the comment with. UUID or issue identifier (e.g., 'LIN-123')" },
+  body: { type: "string", required: true, description: "The comment content in markdown format" },
+  parentId: { type: "string", required: false, description: "The parent comment under which to nest this comment" },
+  doNotSubscribeToIssue: { type: "boolean", required: false, description: "Prevent auto-subscription to the issue the comment is created on" },
+  quotedText: { type: "string", required: false, description: "The text that this comment references (inline comments)" },
+} as const;
+
 // ---------- plugin ----------
 
 export default function linear(rl: RunlinePluginAPI) {
@@ -184,6 +192,22 @@ export default function linear(rl: RunlinePluginAPI) {
           { id: (input as { id: string }).id },
         );
         return data[rootField];
+      },
+    });
+  }
+
+  function commentCreateAction(name: string, description: string) {
+    rl.registerAction(name, {
+      description,
+      inputSchema: COMMENT_CREATE_INPUT_SCHEMA,
+      async execute(input, ctx) {
+        const fields = input as Record<string, unknown>;
+        const data = await gql(
+          key(ctx),
+          `mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { ${COMMENT_FIELDS} } } }`,
+          { input: fields },
+        );
+        return (data.commentCreate as Record<string, unknown>)?.comment;
       },
     });
   }
@@ -546,25 +570,8 @@ export default function linear(rl: RunlinePluginAPI) {
   // Comments
   // =========================================================
 
-  rl.registerAction("issue.addComment", {
-    description: "Add a comment to an issue. Pass parentId to nest as a reply.",
-    inputSchema: {
-      issueId: { type: "string", required: true, description: "The issue to associate the comment with. UUID or issue identifier (e.g., 'LIN-123')" },
-      body: { type: "string", required: true, description: "The comment content in markdown format" },
-      parentId: { type: "string", required: false, description: "The parent comment under which to nest this comment" },
-      doNotSubscribeToIssue: { type: "boolean", required: false, description: "Prevent auto-subscription to the issue the comment is created on" },
-      quotedText: { type: "string", required: false, description: "The text that this comment references (inline comments)" },
-    },
-    async execute(input, ctx) {
-      const fields = input as Record<string, unknown>;
-      const data = await gql(
-        key(ctx),
-        `mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { ${COMMENT_FIELDS} } } }`,
-        { input: fields },
-      );
-      return (data.commentCreate as Record<string, unknown>)?.comment;
-    },
-  });
+  commentCreateAction("issue.addComment", "Add a comment to an issue. Pass parentId to nest as a reply.");
+  commentCreateAction("comment.create", "Create a comment on an issue. Pass parentId to nest as a reply.");
 
   listAction("comment.list", "List comments across the workspace.", "comments", "CommentFilter", COMMENT_FIELDS);
   rl.registerAction("comment.get", {

--- a/packages/runline/src/tests/linear-plugin.test.ts
+++ b/packages/runline/src/tests/linear-plugin.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import linear from "../../../runline-plugins/linear/src/index.js";
+import { createPluginAPI } from "../plugin/api.js";
+import type { ActionContext, PluginDef } from "../plugin/types.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeLinear(): PluginDef {
+  const { api, resolve } = createPluginAPI("linear");
+  linear(api);
+  return resolve();
+}
+
+function getAction(plugin: PluginDef, name: string) {
+  const action = plugin.actions.find((a) => a.name === name);
+  assert.ok(action, `expected linear.${name} to be registered`);
+  return action;
+}
+
+function ctx(): ActionContext {
+  return {
+    connection: {
+      name: "linear",
+      plugin: "linear",
+      config: { apiKey: "lin_test" },
+    },
+    log: {
+      info() {},
+      warn() {},
+      error() {},
+    },
+    async updateConnection() {},
+  };
+}
+
+describe("linear plugin comment actions", () => {
+  it("registers comment.create", () => {
+    const plugin = makeLinear();
+    assert.ok(plugin.actions.some((a) => a.name === "comment.create"));
+  });
+
+  it("comment.create calls Linear's commentCreate mutation", async () => {
+    const action = getAction(makeLinear(), "comment.create");
+
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      assert.equal(String(input), "https://api.linear.app/graphql");
+      assert.equal(init?.method, "POST");
+      assert.equal(
+        init?.headers?.["Authorization" as keyof HeadersInit],
+        "lin_test",
+      );
+
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: { input: Record<string, unknown> };
+      };
+      assert.match(body.query, /commentCreate\(input: \$input\)/);
+      assert.deepEqual(body.variables.input, {
+        issueId: "THE-123",
+        body: "Resolved by PR #123.",
+      });
+
+      return new Response(
+        JSON.stringify({
+          data: {
+            commentCreate: {
+              success: true,
+              comment: {
+                id: "comment-1",
+                body: "Resolved by PR #123.",
+                issue: { id: "issue-1", identifier: "THE-123" },
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const result = await action.execute(
+      { issueId: "THE-123", body: "Resolved by PR #123." },
+      ctx(),
+    );
+
+    assert.deepEqual(result, {
+      id: "comment-1",
+      body: "Resolved by PR #123.",
+      issue: { id: "issue-1", identifier: "THE-123" },
+    });
+  });
+});


### PR DESCRIPTION
Closes #16.

Adds `linear.comment.create({ issueId, body })` for creating comments on Linear issues.

Changes:
- Registers `comment.create` using Linear's `commentCreate` mutation
- Keeps existing `issue.addComment` behavior through shared comment-create registration
- Adds plugin tests for action registration and GraphQL payload

Verification:
- `bun --filter runline build`
- `bun --filter runline check`
- `bun --filter runline test`