### PR TITLE
Add Vercel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/deepl.svg" width="16" height="16" style="vertical-align: middle"> **deepl** | 2 | language | `DEEPL_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/demio.svg" width="16" height="16" style="vertical-align: middle"> **demio** | 4 | event, report | `DEMIO_API_KEY`, `DEMIO_API_SECRET` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/dhl.svg" width="16" height="16" style="vertical-align: middle"> **dhl** | 1 | shipment | `DHL_API_KEY` |
+| **dineplan** | 18 | auth, restaurant, availability, user, search, reservation, listing |  |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/discord.svg" width="16" height="16" style="vertical-align: middle"> **discord** | 13 | channel, member, message | `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/discourse.svg" width="16" height="16" style="vertical-align: middle"> **discourse** | 16 | category, group, post, user, userGroup | `DISCOURSE_HOST`, `DISCOURSE_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/disqus.svg" width="16" height="16" style="vertical-align: middle"> **disqus** | 4 | forum | `DISQUS_API_KEY` |
@@ -106,14 +107,15 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/freshworksCrm.svg" width="16" height="16" style="vertical-align: middle"> **freshworksCrm** | 35 | account, appointment, contact, deal, note, salesActivity, task, search | `FRESHWORKS_CRM_DOMAIN`, `FRESHWORKS_CRM_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/getresponse.png" width="16" height="16" style="vertical-align: middle"> **getresponse** | 5 | contact | `GETRESPONSE_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/ghost.svg" width="16" height="16" style="vertical-align: middle"> **ghost** | 5 | post | `GHOST_URL`, `GHOST_ADMIN_API_KEY` |
-| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/github.svg" width="16" height="16" style="vertical-align: middle"> **github** | 34 | file, issue, release, repository, review, user, organization, workflow | `GITHUB_TOKEN` |
+| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/github.svg" width="16" height="16" style="vertical-align: middle"> **github** | 37 | file, issue, release, commit, branch, repository, review, user, organization, workflow | `GITHUB_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/gitlab.svg" width="16" height="16" style="vertical-align: middle"> **gitlab** | 17 | issue, release, repository, user, file | `GITLAB_TOKEN` |
 | **gmail** | 32 | message, thread, draft, label, profile, alias |  |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/gong.svg" width="16" height="16" style="vertical-align: middle"> **gong** | 4 | call, user | `GONG_ACCESS_KEY`, `GONG_ACCESS_KEY_SECRET` |
-| **googleCalendar** | 11 | calendar, event |  |
+| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/googleAppsScript.svg" width="16" height="16" style="vertical-align: middle"> **googleAppsScript** | 10 | script, project, file, version, deployment, function, process |  |
+| **googleCalendar** | 22 | calendar, event, freeBusy, calendarList, acl, settings |  |
 | **googleContacts** | 10 | contact, group |  |
-| **googleDocs** | 21 | document |  |
-| **googleDrive** | 20 | file, folder, fileFolder, drive |  |
+| **googleDocs** | 30 | document |  |
+| **googleDrive** | 47 | file, folder, fileFolder, drive, comment, reply, revision, changes, permission, accessProposal, about |  |
 | **googleImage** | 1 | image | `GOOGLE_API_KEY` |
 | **googleSheets** | 13 | spreadsheet, sheet |  |
 | **googleSlides** | 7 | presentation, page |  |
@@ -123,7 +125,7 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/grafana.svg" width="16" height="16" style="vertical-align: middle"> **grafana** | 17 | dashboard, team, teamMember, user | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/graphql.svg" width="16" height="16" style="vertical-align: middle"> **graphql** | 2 | query, introspect | `GRAPHQL_ENDPOINT` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/grist.svg" width="16" height="16" style="vertical-align: middle"> **grist** | 4 | record | `GRIST_API_KEY` |
-| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/hackernews.svg" width="16" height="16" style="vertical-align: middle"> **hackernews** | 6 | article, user, all |  |
+| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/hackernews.svg" width="16" height="16" style="vertical-align: middle"> **hackernews** | 6 | article, user, all | — |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/halopsa.svg" width="16" height="16" style="vertical-align: middle"> **halopsa** | 20 | client, site, ticket, user | `HALOPSA_API_URL`, `HALOPSA_CLIENT_ID`, `HALOPSA_CLIENT_SECRET` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/harvest.png" width="16" height="16" style="vertical-align: middle"> **harvest** | 49 | client, project, task, contact, invoice, expense, estimate, user, timeEntry, company | `HARVEST_TOKEN`, `HARVEST_ACCOUNT_ID` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/helpscout.svg" width="16" height="16" style="vertical-align: middle"> **helpscout** | 13 | conversation, customer, mailbox, thread | `HELPSCOUT_ACCESS_TOKEN` |
@@ -157,6 +159,9 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/medium.svg" width="16" height="16" style="vertical-align: middle"> **medium** | 3 | post, publication, me | `MEDIUM_ACCESS_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/messagebird.svg" width="16" height="16" style="vertical-align: middle"> **messagebird** | 2 | sms, balance | `MESSAGEBIRD_ACCESS_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/metabase.svg" width="16" height="16" style="vertical-align: middle"> **metabase** | 10 | question, alert, database, metric | `METABASE_URL`, `METABASE_SESSION_TOKEN` |
+| **microsoftCalendar** | 2 | calendar, event |  |
+| **microsoftFiles** | 5 | files, folder |  |
+| **microsoftMail** | 4 | mail |  |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/misp.svg" width="16" height="16" style="vertical-align: middle"> **misp** | 44 | attribute, event, eventTag, feed, galaxy, noticelist, object, organisation, tag, user, warninglist | `MISP_URL`, `MISP_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/mocean.svg" width="16" height="16" style="vertical-align: middle"> **mocean** | 2 | sms, voice | `MOCEAN_API_KEY`, `MOCEAN_API_SECRET` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/monday.svg" width="16" height="16" style="vertical-align: middle"> **monday** | 18 | board, boardColumn, boardGroup, boardItem | `MONDAY_API_TOKEN` |
@@ -175,18 +180,19 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/oneSimpleApi.svg" width="16" height="16" style="vertical-align: middle"> **oneSimpleApi** | 10 | website, socialProfile, information, utility | `ONE_SIMPLE_API_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/onfleet.svg" width="16" height="16" style="vertical-align: middle"> **onfleet** | 34 | organization, task, worker, admin, hub, team, recipient, container, destination | `ONFLEET_API_KEY` |
 | **openai** | 1 | image | `OPENAI_API_KEY` |
-| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/openThesaurus.png" width="16" height="16" style="vertical-align: middle"> **openThesaurus** | 1 | synonyms |  |
+| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/openThesaurus.png" width="16" height="16" style="vertical-align: middle"> **openThesaurus** | 1 | synonyms | — |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/openweathermap.svg" width="16" height="16" style="vertical-align: middle"> **openweathermap** | 2 | weather | `OPENWEATHERMAP_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/oura.svg" width="16" height="16" style="vertical-align: middle"> **oura** | 4 | profile, summary | `OURA_ACCESS_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/paddle.svg" width="16" height="16" style="vertical-align: middle"> **paddle** | 9 | coupon, payment, plan, product, user | `PADDLE_VENDOR_ID`, `PADDLE_VENDOR_AUTH_CODE` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/pagerduty.svg" width="16" height="16" style="vertical-align: middle"> **pagerduty** | 9 | incident, incidentNote, logEntry, user | `PAGERDUTY_API_TOKEN` |
+| **parallel** | 1 | search | `PARALLEL_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/paypal.svg" width="16" height="16" style="vertical-align: middle"> **paypal** | 4 | payout, payoutItem | `PAYPAL_CLIENT_ID`, `PAYPAL_SECRET` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/peekalink.png" width="16" height="16" style="vertical-align: middle"> **peekalink** | 2 | link | `PEEKALINK_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/phantombuster.png" width="16" height="16" style="vertical-align: middle"> **phantombuster** | 5 | agent | `PHANTOMBUSTER_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/philipsHue.svg" width="16" height="16" style="vertical-align: middle"> **philipsHue** | 4 | light | `PHILIPS_HUE_ACCESS_TOKEN`, `PHILIPS_HUE_USERNAME` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/pipedrive.svg" width="16" height="16" style="vertical-align: middle"> **pipedrive** | 47 | activity, deal, dealProduct, file, lead, note, organization, person, product | `PIPEDRIVE_API_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/plivo.svg" width="16" height="16" style="vertical-align: middle"> **plivo** | 3 | sms, mms, call | `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN` |
-| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/postbin.svg" width="16" height="16" style="vertical-align: middle"> **postbin** | 6 | bin, request |  |
+| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/postbin.svg" width="16" height="16" style="vertical-align: middle"> **postbin** | 6 | bin, request | — |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/posthog.svg" width="16" height="16" style="vertical-align: middle"> **posthog** | 5 | alias, event, identity, track | `POSTHOG_URL`, `POSTHOG_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/profitwell.svg" width="16" height="16" style="vertical-align: middle"> **profitwell** | 2 | company, metric | `PROFITWELL_ACCESS_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/pushbullet.svg" width="16" height="16" style="vertical-align: middle"> **pushbullet** | 4 | push | `PUSHBULLET_ACCESS_TOKEN` |
@@ -194,7 +200,7 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/pushover.svg" width="16" height="16" style="vertical-align: middle"> **pushover** | 1 | message | `PUSHOVER_API_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/quickbase.png" width="16" height="16" style="vertical-align: middle"> **quickbase** | 8 | field, file, record, report | `QUICKBASE_HOSTNAME`, `QUICKBASE_USER_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/quickbooks.svg" width="16" height="16" style="vertical-align: middle"> **quickbooks** | 45 | bill, customer, employee, estimate, invoice, item, payment, purchase, vendor | `QUICKBOOKS_ACCESS_TOKEN`, `QUICKBOOKS_COMPANY_ID` |
-| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/quickchart.svg" width="16" height="16" style="vertical-align: middle"> **quickchart** | 1 | chart |  |
+| <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/quickchart.svg" width="16" height="16" style="vertical-align: middle"> **quickchart** | 1 | chart | — |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/raindrop.svg" width="16" height="16" style="vertical-align: middle"> **raindrop** | 13 | bookmark, collection, tag, user | `RAINDROP_ACCESS_TOKEN` |
 | **recraft** | 1 | image | `RECRAFT_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/reddit.svg" width="16" height="16" style="vertical-align: middle"> **reddit** | 10 | post, comment, subreddit, user |  |
@@ -216,6 +222,7 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/splunk.svg" width="16" height="16" style="vertical-align: middle"> **splunk** | 16 | search, alert, report, user | `SPLUNK_BASE_URL`, `SPLUNK_AUTH_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/spotify.svg" width="16" height="16" style="vertical-align: middle"> **spotify** | 30 | player, album, artist, playlist, track, library, myData | `SPOTIFY_ACCESS_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/stackby.png" width="16" height="16" style="vertical-align: middle"> **stackby** | 4 | row | `STACKBY_API_KEY` |
+| **steel** | 3 | browser | `STEEL_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/storyblok.svg" width="16" height="16" style="vertical-align: middle"> **storyblok** | 7 | content, management |  |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/strapi.svg" width="16" height="16" style="vertical-align: middle"> **strapi** | 5 | entry | `STRAPI_URL` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/strava.svg" width="16" height="16" style="vertical-align: middle"> **strava** | 9 | activity | `STRAVA_ACCESS_TOKEN` |
@@ -239,6 +246,7 @@ runline exec 'return await github.user.listRepos({ username: "torvalds" })'
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/uproc.png" width="16" height="16" style="vertical-align: middle"> **uproc** | 1 | process | `UPROC_EMAIL`, `UPROC_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/uptimerobot.svg" width="16" height="16" style="vertical-align: middle"> **uptimerobot** | 22 | account, monitor, alertContact, maintenanceWindow, publicStatusPage | `UPTIMEROBOT_API_KEY` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/urlscanio.svg" width="16" height="16" style="vertical-align: middle"> **urlscanio** | 3 | scan | `URLSCANIO_API_KEY` |
+| **vercel** | 14 | whoami, project, deployment, env | `VERCEL_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/vero.svg" width="16" height="16" style="vertical-align: middle"> **vero** | 8 | user, event | `VERO_AUTH_TOKEN` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/vonage.svg" width="16" height="16" style="vertical-align: middle"> **vonage** | 1 | sms | `VONAGE_API_KEY`, `VONAGE_API_SECRET` |
 | <img src="https://raw.githubusercontent.com/Michaelliv/runline/main/packages/runline-plugins/icons/wekan.svg" width="16" height="16" style="vertical-align: middle"> **wekan** | 24 | board, list, card, cardComment, checklist, checklistItem | `WEKAN_URL`, `WEKAN_TOKEN` |

--- a/packages/runline-plugins/vercel/README.md
+++ b/packages/runline-plugins/vercel/README.md
@@ -1,0 +1,52 @@
+# Vercel plugin
+
+Set `VERCEL_TOKEN` to a Vercel access token from <https://vercel.com/account/settings/tokens>. Personal-account resources work with only the token. Team-owned resources usually need `VERCEL_TEAM_ID` or per-call `teamId`; the plugin appends the configured team scope to every request.
+
+```json
+{
+  "connections": [
+    {
+      "name": "vercel",
+      "plugin": "vercel",
+      "config": {
+        "token": "vcp_...",
+        "teamId": "team_..."
+      }
+    }
+  ]
+}
+```
+
+Examples:
+
+```ts
+await vercel.whoami();
+
+const projects = await vercel.project.list({ limit: 20 });
+const deployments = await vercel.deployment.list({ projectId: "prj_...", state: "ERROR,READY", limit: 10 });
+
+const buildLogs = await vercel.deployment.logs({
+  idOrUrl: "dpl_...",
+  builds: 1,
+  limit: 100,
+  direction: "backward",
+});
+
+const runtimeLogs = await vercel.deployment.runtimeLogs({
+  projectId: "prj_...",
+  deploymentId: "dpl_...",
+  since: Date.now() - 30 * 60 * 1000,
+});
+
+await vercel.env.set({
+  projectIdOrName: "my-app",
+  key: "API_URL",
+  value: "https://api.example.com",
+  type: "encrypted",
+  target: "production",
+});
+
+await vercel.env.delete({ projectIdOrName: "my-app", id: "env_..." });
+```
+
+`env.set` creates when `id` is omitted and updates when `id` is provided. Creates require `key`, `value`, `type`, and either `target` or `customEnvironmentIds`; string `target` values are normalized to Vercel's required array shape. Be explicit about `target` and `gitBranch`; environment variable writes affect the selected project/environment scope and usually require a redeploy before deployed code sees the new value.

--- a/packages/runline-plugins/vercel/src/account.ts
+++ b/packages/runline-plugins/vercel/src/account.ts
@@ -1,0 +1,13 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import { TEAM_INPUT_SCHEMA, api } from "./shared.js";
+
+export function registerAccountActions(rl: RunlinePluginAPI) {
+  rl.registerAction("whoami", {
+    description: "Validate the Vercel token and return the authenticated user/account context.",
+    inputSchema: t.Object(TEAM_INPUT_SCHEMA),
+    async execute(input, ctx) {
+      return api(ctx, "/v2/user", { query: (input ?? {}) as Record<string, unknown> });
+    },
+  });
+}

--- a/packages/runline-plugins/vercel/src/deployments.ts
+++ b/packages/runline-plugins/vercel/src/deployments.ts
@@ -1,0 +1,87 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import { LIST_INPUT_SCHEMA, TEAM_INPUT_SCHEMA, api, bindGetAction } from "./shared.js";
+
+export function registerDeploymentActions(rl: RunlinePluginAPI) {
+  const getAction = bindGetAction(rl);
+
+  rl.registerAction("deployment.list", {
+    description: "List Vercel deployments. Filter by project, state, target, user, or time window.",
+    inputSchema: t.Object({
+      ...LIST_INPUT_SCHEMA,
+      projectId: t.Optional(t.String({ description: "Project ID to filter deployments" })),
+      projectIds: t.Optional(t.Array(t.String(), { description: "Project IDs to filter deployments" })),
+      app: t.Optional(t.String({ description: "Project name/app filter" })),
+      target: t.Optional(t.String({ description: "production, preview, or a custom target" })),
+      state: t.Optional(t.String({ description: "Comma-separated deployment states, e.g. BUILDING,READY,ERROR" })),
+      users: t.Optional(t.String({ description: "Comma-separated Vercel user IDs" })),
+    }),
+    async execute(input, ctx) {
+      return api(ctx, "/v7/deployments", { query: (input ?? {}) as Record<string, unknown> });
+    },
+  });
+
+  getAction("deployment.get", "Get a Vercel deployment by ID or URL.", (id) => `/v13/deployments/${encodeURIComponent(id)}`);
+
+  rl.registerAction("deployment.logs", {
+    description: "Get build/deployment logs/events for a deployment. Use builds=1 for build logs and limit/since/until to avoid huge responses.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      idOrUrl: t.String({ description: "Deployment ID or URL" }),
+      limit: t.Optional(t.Number({ description: "Maximum events. Vercel supports -1 for all available logs" })),
+      direction: t.Optional(t.String({ description: "forward or backward" })),
+      follow: t.Optional(t.Number({ description: "0 or 1. Avoid 1 in short-lived agent calls unless intentionally streaming" })),
+      name: t.Optional(t.String({ description: "Build ID/name" })),
+      since: t.Optional(t.Number({ description: "Start timestamp in milliseconds" })),
+      until: t.Optional(t.Number({ description: "End timestamp in milliseconds" })),
+      statusCode: t.Optional(t.String({ description: "HTTP status filter such as 5xx" })),
+      delimiter: t.Optional(t.Number({ description: "0 or 1" })),
+      builds: t.Optional(t.Number({ description: "0 or 1" })),
+    }),
+    async execute(input, ctx) {
+      const { idOrUrl, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v3/deployments/${encodeURIComponent(String(idOrUrl))}/events`, { query });
+    },
+  });
+
+  rl.registerAction("deployment.runtimeLogs", {
+    description: "Get runtime logs for a deployment. Requires projectId and deploymentId; use limit/since/until to keep responses bounded.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectId: t.String({ description: "Project ID" }),
+      deploymentId: t.String({ description: "Deployment ID" }),
+      limit: t.Optional(t.Number({ description: "Maximum logs when supported by Vercel" })),
+      since: t.Optional(t.Number({ description: "Start timestamp in milliseconds" })),
+      until: t.Optional(t.Number({ description: "End timestamp in milliseconds" })),
+    }),
+    async execute(input, ctx) {
+      const { projectId, deploymentId, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v1/projects/${encodeURIComponent(String(projectId))}/deployments/${encodeURIComponent(String(deploymentId))}/runtime-logs`, { query });
+    },
+  });
+
+  rl.registerAction("deployment.cancel", {
+    description: "Cancel a queued or building Vercel deployment.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      id: t.String({ description: "Deployment ID" }),
+    }),
+    async execute(input, ctx) {
+      const { id, ...query } = input as { id: string } & Record<string, unknown>;
+      return api(ctx, `/v12/deployments/${encodeURIComponent(id)}/cancel`, { method: "PATCH", query });
+    },
+  });
+
+  rl.registerAction("deployment.promote", {
+    description: "Promote an existing deployment to production for a project, where supported by Vercel.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectId: t.String({ description: "Project ID" }),
+      deploymentId: t.String({ description: "Deployment ID to promote" }),
+    }),
+    async execute(input, ctx) {
+      const { projectId, deploymentId, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v10/projects/${encodeURIComponent(String(projectId))}/promote/${encodeURIComponent(String(deploymentId))}`, { method: "POST", query });
+    },
+  });
+}

--- a/packages/runline-plugins/vercel/src/env.ts
+++ b/packages/runline-plugins/vercel/src/env.ts
@@ -1,0 +1,108 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import { TEAM_INPUT_SCHEMA, api } from "./shared.js";
+
+const targetSchema = t.Union([t.String(), t.Array(t.String())], {
+  description: "production, preview, development, custom environment, or array of targets",
+});
+
+function normalizeEnvBody(body: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...body };
+  if (typeof normalized.target === "string") normalized.target = [normalized.target];
+  return normalized;
+}
+
+function assertCreateEnvInput(body: Record<string, unknown>): void {
+  if (!body.key || !body.value || !body.type) {
+    throw new Error("env.set create requires key, value, and type");
+  }
+  if (!body.target && !body.customEnvironmentIds) {
+    throw new Error("env.set create requires target or customEnvironmentIds");
+  }
+}
+
+export function registerEnvActions(rl: RunlinePluginAPI) {
+  rl.registerAction("env.list", {
+    description: "List environment variables for a Vercel project.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectIdOrName: t.String({ description: "Project ID or name" }),
+      target: t.Optional(t.String({ description: "production, preview, development, or custom environment" })),
+      gitBranch: t.Optional(t.String({ description: "Git branch filter" })),
+      decrypt: t.Optional(t.Boolean({ description: "Ask Vercel to include decrypted values when permitted" })),
+      source: t.Optional(t.String({ description: "Environment variable source filter" })),
+    }),
+    async execute(input, ctx) {
+      const { projectIdOrName, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v10/projects/${encodeURIComponent(String(projectIdOrName))}/env`, { query });
+    },
+  });
+
+  rl.registerAction("env.get", {
+    description: "Get one environment variable by ID for a Vercel project, including decrypted value when permitted.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectIdOrName: t.String({ description: "Project ID or name" }),
+      id: t.String({ description: "Environment variable ID" }),
+    }),
+    async execute(input, ctx) {
+      const { projectIdOrName, id, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v1/projects/${encodeURIComponent(String(projectIdOrName))}/env/${encodeURIComponent(String(id))}`, { query });
+    },
+  });
+
+  rl.registerAction("env.set", {
+    description: "Create or update a Vercel project environment variable. Without id, creates a variable and requires key, value, type, and target/customEnvironmentIds. With id, updates that exact variable. Be explicit about target to avoid changing the wrong environment.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectIdOrName: t.String({ description: "Project ID or name" }),
+      id: t.Optional(t.String({ description: "Environment variable ID. When provided, env.set updates instead of creating." })),
+      key: t.Optional(t.String({ description: "Variable name" })),
+      value: t.Optional(t.String({ description: "Variable value" })),
+      target: t.Optional(targetSchema),
+      customEnvironmentIds: t.Optional(t.Array(t.String(), { description: "Custom environment IDs for custom-environment scoped variables" })),
+      type: t.Optional(t.String({ description: "Vercel env var type: system, encrypted, plain, or sensitive" })),
+      gitBranch: t.Optional(t.String({ description: "Git branch for branch-scoped preview variables" })),
+      comment: t.Optional(t.String({ description: "Optional comment" })),
+      variables: t.Optional(t.Array(t.Object({}, { description: "Raw Vercel env var objects for batch create" }))),
+    }),
+    async execute(input, ctx) {
+      const { projectIdOrName, id, teamId, slug, variables, ...fields } = input as Record<string, unknown>;
+      const query = { teamId, slug };
+      if (id) {
+        return api(ctx, `/v9/projects/${encodeURIComponent(String(projectIdOrName))}/env/${encodeURIComponent(String(id))}`, {
+          method: "PATCH",
+          query,
+          body: normalizeEnvBody(fields),
+        });
+      }
+      if (Array.isArray(variables)) {
+        return api(ctx, `/v10/projects/${encodeURIComponent(String(projectIdOrName))}/env`, {
+          method: "POST",
+          query,
+          body: variables.map((item) => normalizeEnvBody(item as Record<string, unknown>)),
+        });
+      }
+      const body = normalizeEnvBody(fields);
+      assertCreateEnvInput(body);
+      return api(ctx, `/v10/projects/${encodeURIComponent(String(projectIdOrName))}/env`, { method: "POST", query, body });
+    },
+  });
+
+  rl.registerAction("env.delete", {
+    description: "Delete an environment variable from a Vercel project. This removes the variable for the specified project/environment scope.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectIdOrName: t.String({ description: "Project ID or name" }),
+      id: t.String({ description: "Environment variable ID" }),
+      customEnvironmentId: t.Optional(t.String({ description: "Custom environment ID when required" })),
+    }),
+    async execute(input, ctx) {
+      const { projectIdOrName, id, customEnvironmentId, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v9/projects/${encodeURIComponent(String(projectIdOrName))}/env/${encodeURIComponent(String(id))}`, {
+        method: "DELETE",
+        query: { ...query, customEnvironmentId },
+      });
+    },
+  });
+}

--- a/packages/runline-plugins/vercel/src/index.ts
+++ b/packages/runline-plugins/vercel/src/index.ts
@@ -1,0 +1,30 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import { registerAccountActions } from "./account.js";
+import { registerDeploymentActions } from "./deployments.js";
+import { registerEnvActions } from "./env.js";
+import { registerProjectActions } from "./projects.js";
+
+export default function vercel(rl: RunlinePluginAPI) {
+  rl.setName("vercel");
+  rl.setVersion("0.1.0");
+  rl.setConnectionSchema(t.Object({
+    token: t.String({
+      description: "Vercel access token (https://vercel.com/account/settings/tokens)",
+      env: "VERCEL_TOKEN",
+    }),
+    teamId: t.Optional(t.String({
+      description: "Optional Vercel Team ID. Added as teamId to every API request.",
+      env: "VERCEL_TEAM_ID",
+    })),
+    slug: t.Optional(t.String({
+      description: "Optional Vercel Team slug. Added as slug to every API request when teamId is not used.",
+      env: "VERCEL_TEAM_SLUG",
+    })),
+  }));
+
+  registerAccountActions(rl);
+  registerProjectActions(rl);
+  registerDeploymentActions(rl);
+  registerEnvActions(rl);
+}

--- a/packages/runline-plugins/vercel/src/projects.ts
+++ b/packages/runline-plugins/vercel/src/projects.ts
@@ -1,0 +1,34 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import { LIST_INPUT_SCHEMA, TEAM_INPUT_SCHEMA, api, bindGetAction } from "./shared.js";
+
+export function registerProjectActions(rl: RunlinePluginAPI) {
+  const getAction = bindGetAction(rl);
+
+  rl.registerAction("project.list", {
+    description: "List Vercel projects visible to the token.",
+    inputSchema: t.Object({
+      ...LIST_INPUT_SCHEMA,
+      search: t.Optional(t.String({ description: "Search by project name" })),
+    }),
+    async execute(input, ctx) {
+      const opts = (input ?? {}) as Record<string, unknown>;
+      return api(ctx, "/v10/projects", { query: opts });
+    },
+  });
+
+  getAction("project.get", "Get a Vercel project by ID or name.", (id) => `/v9/projects/${encodeURIComponent(id)}`);
+
+  rl.registerAction("project.domains", {
+    description: "List domains configured for a Vercel project.",
+    inputSchema: t.Object({
+      ...TEAM_INPUT_SCHEMA,
+      projectIdOrName: t.String({ description: "Project ID or name" }),
+      limit: t.Optional(t.Number({ description: "Maximum number of domains" })),
+    }),
+    async execute(input, ctx) {
+      const { projectIdOrName, ...query } = input as Record<string, unknown>;
+      return api(ctx, `/v9/projects/${encodeURIComponent(String(projectIdOrName))}/domains`, { query });
+    },
+  });
+}

--- a/packages/runline-plugins/vercel/src/shared.ts
+++ b/packages/runline-plugins/vercel/src/shared.ts
@@ -1,0 +1,94 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+
+const BASE_URL = "https://api.vercel.com";
+
+export type Ctx = { connection: { config: Record<string, unknown> } };
+
+export function token(ctx: Ctx): string {
+  return ctx.connection.config.token as string;
+}
+
+export type RequestOptions = {
+  method?: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  headers?: Record<string, string>;
+};
+
+export async function api(
+  ctx: Ctx,
+  path: string,
+  options: RequestOptions = {},
+): Promise<unknown> {
+  const url = new URL(path, BASE_URL);
+  const query = {
+    teamId: ctx.connection.config.teamId,
+    slug: ctx.connection.config.slug,
+    ...(options.query ?? {}),
+  };
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === "") continue;
+    if (Array.isArray(value)) {
+      for (const item of value) url.searchParams.append(key, String(item));
+    } else {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const init: RequestInit = {
+    method: options.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${token(ctx)}`,
+      "Content-Type": "application/json",
+      ...(options.headers ?? {}),
+    },
+  };
+  if (options.body !== undefined) init.body = JSON.stringify(options.body);
+
+  const res = await fetch(url.toString(), init);
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Vercel API error ${res.status}: ${text || res.statusText}`);
+  }
+  if (!text) return {};
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json") || text.startsWith("{") || text.startsWith("[")) {
+    return JSON.parse(text);
+  }
+  return text;
+}
+
+export const TEAM_INPUT_SCHEMA = {
+  teamId: t.Optional(t.String({ description: "Override the configured Vercel Team ID for this call" })),
+  slug: t.Optional(t.String({ description: "Override the configured Vercel Team slug for this call" })),
+} as const;
+
+export const LIST_INPUT_SCHEMA = {
+  ...TEAM_INPUT_SCHEMA,
+  limit: t.Optional(t.Number({ description: "Maximum number of results" })),
+  since: t.Optional(t.Number({ description: "Timestamp in milliseconds to start from" })),
+  until: t.Optional(t.Number({ description: "Timestamp in milliseconds to end at" })),
+  from: t.Optional(t.Number({ description: "Pagination timestamp/cursor supported by Vercel" })),
+  to: t.Optional(t.Number({ description: "Pagination timestamp/cursor supported by Vercel" })),
+} as const;
+
+export function bindGetAction(rl: RunlinePluginAPI) {
+  return (
+    name: string,
+    description: string,
+    pathForId: (id: string) => string,
+  ) => {
+    rl.registerAction(name, {
+      description,
+      inputSchema: t.Object({
+        id: t.String({ description: "Resource ID, name, or URL" }),
+        ...TEAM_INPUT_SCHEMA,
+      }),
+      async execute(input, ctx) {
+        const { id, ...query } = input as { id: string } & Record<string, unknown>;
+        return api(ctx, pathForId(id), { query });
+      },
+    });
+  };
+}

--- a/packages/runline/scripts/generate-plugin-table.js
+++ b/packages/runline/scripts/generate-plugin-table.js
@@ -12,6 +12,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverPlugins } from "../dist/plugin/loader.js";
+import { connectionFields } from "../dist/plugin/schema.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ICONS_DIR = join(__dirname, "..", "..", "runline-plugins", "icons");
@@ -39,8 +40,9 @@ for (const p of plugins) {
   const resources = [...new Set(p.actions.map((a) => a.name.split(".")[0]))];
   const resourceList = resources.join(", ");
 
-  const authFields = p.connectionConfigSchema
-    ? Object.entries(p.connectionConfigSchema)
+  const fields = connectionFields(p.connectionConfigSchema);
+  const authFields = Object.keys(fields).length
+    ? Object.entries(fields)
         .filter(([, field]) => field.required !== false)
         .map(([key, field]) => (field.env ? `\`${field.env}\`` : `\`${key}\``))
         .join(", ")

--- a/packages/runline/src/tests/vercel-plugin.test.ts
+++ b/packages/runline/src/tests/vercel-plugin.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import vercel from "../../../runline-plugins/vercel/src/index.js";
+import { createPluginAPI } from "../plugin/api.js";
+import type { ActionContext, PluginDef } from "../plugin/types.js";
+
+const originalFetch = globalThis.fetch;
+
+const VERCEL_ACTIONS = [
+  "deployment.cancel",
+  "deployment.get",
+  "deployment.list",
+  "deployment.logs",
+  "deployment.promote",
+  "deployment.runtimeLogs",
+  "env.delete",
+  "env.get",
+  "env.list",
+  "env.set",
+  "project.domains",
+  "project.get",
+  "project.list",
+  "whoami",
+] as const;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeVercel(): PluginDef {
+  const { api, resolve } = createPluginAPI("vercel");
+  vercel(api);
+  return resolve();
+}
+
+function getAction(plugin: PluginDef, name: string) {
+  const action = plugin.actions.find((a) => a.name === name);
+  assert.ok(action, `expected vercel.${name} to be registered`);
+  return action;
+}
+
+function ctx(config: Record<string, unknown> = {}): ActionContext {
+  return {
+    connection: {
+      name: "vercel",
+      plugin: "vercel",
+      config: { token: "vcp_test", ...config },
+    },
+    log: { info() {}, warn() {}, error() {} },
+    async updateConnection() {},
+  };
+}
+
+function mockVercel(
+  assertRequest: (request: {
+    url: URL;
+    init?: RequestInit;
+    body?: unknown;
+  }) => unknown,
+) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    assert.equal(url.origin, "https://api.vercel.com");
+    assert.equal(
+      init?.headers?.["Authorization" as keyof HeadersInit],
+      "Bearer vcp_test",
+    );
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    const data = assertRequest({ url, init, body });
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+describe("vercel plugin action surface", () => {
+  it("registers the expected public actions", () => {
+    const plugin = makeVercel();
+    assert.deepEqual(plugin.actions.map((a) => a.name).sort(), [
+      ...VERCEL_ACTIONS,
+    ]);
+  });
+});
+
+describe("vercel plugin REST actions", () => {
+  it("adds auth and team scope to project.list", async () => {
+    const action = getAction(makeVercel(), "project.list");
+
+    mockVercel(({ url, init }) => {
+      assert.equal(url.pathname, "/v10/projects");
+      assert.equal(url.searchParams.get("teamId"), "team_123");
+      assert.equal(url.searchParams.get("limit"), "2");
+      assert.equal(url.searchParams.get("search"), "docs");
+      assert.equal(init?.method, "GET");
+      return { projects: [{ id: "prj_1", name: "docs" }] };
+    });
+
+    assert.deepEqual(
+      await action.execute(
+        { limit: 2, search: "docs" },
+        ctx({ teamId: "team_123" }),
+      ),
+      {
+        projects: [{ id: "prj_1", name: "docs" }],
+      },
+    );
+  });
+
+  it("gets deployments and build logs", async () => {
+    const get = getAction(makeVercel(), "deployment.get");
+    const logs = getAction(makeVercel(), "deployment.logs");
+    let count = 0;
+
+    mockVercel(({ url }) => {
+      count++;
+      if (count === 1) {
+        assert.equal(url.pathname, "/v13/deployments/dpl_123");
+        return { id: "dpl_123", readyState: "READY" };
+      }
+      assert.equal(url.pathname, "/v3/deployments/dpl_123/events");
+      assert.equal(url.searchParams.get("builds"), "1");
+      assert.equal(url.searchParams.get("limit"), "10");
+      return [{ type: "stdout", payload: { text: "built" } }];
+    });
+
+    assert.deepEqual(await get.execute({ id: "dpl_123" }, ctx()), {
+      id: "dpl_123",
+      readyState: "READY",
+    });
+    assert.deepEqual(
+      await logs.execute({ idOrUrl: "dpl_123", builds: 1, limit: 10 }, ctx()),
+      [{ type: "stdout", payload: { text: "built" } }],
+    );
+  });
+
+  it("gets runtime logs with project and deployment ids", async () => {
+    const action = getAction(makeVercel(), "deployment.runtimeLogs");
+
+    mockVercel(({ url }) => {
+      assert.equal(
+        url.pathname,
+        "/v1/projects/prj_1/deployments/dpl_1/runtime-logs",
+      );
+      assert.equal(url.searchParams.get("since"), "100");
+      return [{ level: "info", message: "ok" }];
+    });
+
+    assert.deepEqual(
+      await action.execute(
+        { projectId: "prj_1", deploymentId: "dpl_1", since: 100 },
+        ctx(),
+      ),
+      [{ level: "info", message: "ok" }],
+    );
+  });
+
+  it("validates the token with whoami and supports deployment cancel/promote", async () => {
+    const whoami = getAction(makeVercel(), "whoami");
+    const cancel = getAction(makeVercel(), "deployment.cancel");
+    const promote = getAction(makeVercel(), "deployment.promote");
+    let count = 0;
+
+    mockVercel(({ url, init }) => {
+      count++;
+      if (count === 1) {
+        assert.equal(url.pathname, "/v2/user");
+        return { user: { id: "user_1" } };
+      }
+      if (count === 2) {
+        assert.equal(url.pathname, "/v12/deployments/dpl_1/cancel");
+        assert.equal(init?.method, "PATCH");
+        return { canceled: true };
+      }
+      assert.equal(url.pathname, "/v10/projects/prj_1/promote/dpl_1");
+      assert.equal(init?.method, "POST");
+      return { promoted: true };
+    });
+
+    assert.deepEqual(await whoami.execute({}, ctx()), {
+      user: { id: "user_1" },
+    });
+    assert.deepEqual(await cancel.execute({ id: "dpl_1" }, ctx()), {
+      canceled: true,
+    });
+    assert.deepEqual(
+      await promote.execute(
+        { projectId: "prj_1", deploymentId: "dpl_1" },
+        ctx(),
+      ),
+      { promoted: true },
+    );
+  });
+
+  it("manages project env vars through Vercel env endpoints", async () => {
+    const list = getAction(makeVercel(), "env.list");
+    const set = getAction(makeVercel(), "env.set");
+    const del = getAction(makeVercel(), "env.delete");
+    let count = 0;
+
+    mockVercel(({ url, init, body }) => {
+      count++;
+      if (count === 1) {
+        assert.equal(url.pathname, "/v10/projects/my-app/env");
+        assert.equal(url.searchParams.get("target"), "production");
+        return { envs: [] };
+      }
+      if (count === 2) {
+        assert.equal(url.pathname, "/v10/projects/my-app/env");
+        assert.equal(init?.method, "POST");
+        assert.deepEqual(body, {
+          key: "API_URL",
+          value: "https://example.test",
+          type: "encrypted",
+          target: ["production"],
+        });
+        return { created: [{ id: "env_1" }] };
+      }
+      if (count === 3) {
+        assert.equal(url.pathname, "/v9/projects/my-app/env/env_1");
+        assert.equal(init?.method, "PATCH");
+        assert.deepEqual(body, { value: "updated" });
+        return { id: "env_1" };
+      }
+      assert.equal(url.pathname, "/v9/projects/my-app/env/env_1");
+      assert.equal(init?.method, "DELETE");
+      return { removed: true };
+    });
+
+    await list.execute(
+      { projectIdOrName: "my-app", target: "production" },
+      ctx(),
+    );
+    await set.execute(
+      {
+        projectIdOrName: "my-app",
+        key: "API_URL",
+        value: "https://example.test",
+        type: "encrypted",
+        target: "production",
+      },
+      ctx(),
+    );
+    await set.execute(
+      { projectIdOrName: "my-app", id: "env_1", value: "updated" },
+      ctx(),
+    );
+    assert.deepEqual(
+      await del.execute({ projectIdOrName: "my-app", id: "env_1" }, ctx()),
+      { removed: true },
+    );
+  });
+
+  it("throws useful Vercel API errors", async () => {
+    const action = getAction(makeVercel(), "project.get");
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: { message: "nope" } }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    await assert.rejects(
+      action.execute({ id: "missing" }, ctx()),
+      /Vercel API error 403/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new Vercel plugin with PAT auth, optional team scope, and shared REST helper.
- Implements whoami, project discovery, deployment inspection/logs/cancel/promote, and project env var list/get/set/delete actions.
- Documents token setup, personal vs team usage, failed-deployment inspection, and env var update examples.
- Adds unit coverage for action registration, auth/team query construction, endpoint routing, env writes/deletes, deployment logs, cancel/promote, and API error formatting.

Closes #27.

## Verification
- bun test packages/runline/src/tests/vercel-plugin.test.ts — 6 pass
- bun run build — pass
- bunx @biomejs/biome check . — pass
- Non-mutating live smoke with short-lived Vercel token: whoami, project.list, and deployment.list all returned successfully.
