### PR TITLE
Replace QuickJS sandbox with worker_threads executor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/pi-runline": {
       "name": "pi-runline",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "runline": "^0.2.2",
       },
@@ -24,7 +24,7 @@
     },
     "packages/runline": {
       "name": "runline",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "bin": {
         "runline": "./dist/main.js",
       },
@@ -33,7 +33,6 @@
         "commander": "^14.0.3",
         "jiti": "^2.7.0",
         "proper-lockfile": "^4.1.2",
-        "quickjs-emscripten": "^0.32.0",
         "rrule": "^2.8.1",
         "typebox": "^1.1.35",
       },
@@ -158,16 +157,6 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
-
-    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
-
-    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
-
-    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
-
-    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
-
-    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
 
@@ -540,10 +529,6 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
-
-    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
-
-    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 

--- a/packages/runline/package.json
+++ b/packages/runline/package.json
@@ -75,7 +75,6 @@
     "commander": "^14.0.3",
     "jiti": "^2.7.0",
     "proper-lockfile": "^4.1.2",
-    "quickjs-emscripten": "^0.32.0",
     "rrule": "^2.8.1",
     "typebox": "^1.1.35"
   }

--- a/packages/runline/src/core/engine.ts
+++ b/packages/runline/src/core/engine.ts
@@ -1,12 +1,5 @@
 import { readFileSync } from "node:fs";
-import {
-  getQuickJS,
-  type QuickJSContext,
-  type QuickJSDeferredPromise,
-  type QuickJSHandle,
-  type QuickJSRuntime,
-  shouldInterruptAfterDeadline,
-} from "quickjs-emscripten";
+import { Worker } from "node:worker_threads";
 import { applyEnvOverrides, updateConnectionConfig } from "../config/loader.js";
 import type { RunlineConfig } from "../config/types.js";
 import type { PluginRegistry } from "../plugin/registry.js";
@@ -34,6 +27,48 @@ export interface EngineOptions {
   memoryLimitBytes?: number;
 }
 
+// Messages worker → host
+type WorkerMessage =
+  | { t: "log"; level: string; line: string }
+  | { t: "invoke"; id: number; path: string; args: unknown }
+  | { t: "done"; ok: boolean; result?: unknown; error?: string };
+
+// Messages host → worker (action invocation replies)
+type InvokeReply =
+  | { t: "result"; id: number; ok: true; value: unknown }
+  | { t: "result"; id: number; ok: false; error: string };
+
+/**
+ * Whether to arm the host-side RSS watchdog for a worker run.
+ *
+ * node enforces resourceLimits.maxOldGenerationSizeMb natively, and the
+ * watchdog measures *whole-process* RSS — arming it there would risk false
+ * kills from unrelated host allocations (e.g. a concurrent execute). bun
+ * ignores resourceLimits, so the watchdog is the only memory backstop.
+ */
+export function shouldArmRssWatchdog(
+  versions: Partial<Record<string, string>> = process.versions,
+): boolean {
+  return Boolean(versions.bun);
+}
+
+// Extra slack on top of the configured memory limit for the RSS watchdog,
+// since whole-process RSS includes the host's own working set.
+const RSS_WATCHDOG_SLACK_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Executes agent code in a node:worker_threads worker.
+ *
+ * The worker is an ergonomic coding surface, not a security sandbox: agent
+ * code gets the full host JS runtime (Buffer, crypto, etc.) plus injected
+ * action proxies. Isolation properties we do enforce, fail-soft:
+ *
+ * - timeout: worker.terminate() — interrupts even `while(true){}`
+ * - memory: resourceLimits.maxOldGenerationSizeMb (node) + an RSS-delta
+ *   watchdog fallback; both surface as a clean "Memory limit exceeded" error
+ * - crash containment: a dead worker never takes the host process down, and
+ *   each execute() gets a fresh worker, so the engine stays usable
+ */
 export class ExecutionEngine {
   private registry: PluginRegistry;
   private config: RunlineConfig;
@@ -47,146 +82,137 @@ export class ExecutionEngine {
     const timeoutMs = options?.timeoutMs ?? this.config.timeoutMs;
     const memoryLimitBytes =
       options?.memoryLimitBytes ?? this.config.memoryLimitBytes;
-    const deadlineMs = Date.now() + timeoutMs;
     const logs: string[] = [];
-    const pendingDeferreds = new Set<QuickJSDeferredPromise>();
 
-    const QuickJS = await getQuickJS();
-    const runtime = QuickJS.newRuntime();
+    const plugins = this.registry.listPlugins();
+    const source = buildWorkerSource(
+      code,
+      plugins.map((p) => p.name),
+      buildHelpData(plugins),
+    );
 
-    try {
-      runtime.setMemoryLimit(memoryLimitBytes);
-      runtime.setInterruptHandler(shouldInterruptAfterDeadline(deadlineMs));
-
-      const context = runtime.newContext();
+    return new Promise<ExecuteResult>((resolve) => {
+      const memoryLimitMb = Math.max(
+        8,
+        Math.floor(memoryLimitBytes / (1024 * 1024)),
+      );
+      let worker: Worker;
       try {
-        // Inject log bridge
-        const logBridge = context.newFunction(
-          "__runline_log",
-          (levelHandle, lineHandle) => {
-            const level = context.getString(levelHandle);
-            const line = context.getString(lineHandle);
-            logs.push(`[${level}] ${line}`);
-            return context.undefined;
-          },
-        );
-        context.setProp(context.global, "__runline_log", logBridge);
-        logBridge.dispose();
-
-        // Inject action bridge
-        const actionBridge = context.newFunction(
-          "__runline_invoke",
-          (pathHandle, argsHandle) => {
-            const path = context.getString(pathHandle);
-            const args =
-              argsHandle === undefined ||
-              context.typeof(argsHandle) === "undefined"
-                ? undefined
-                : context.dump(argsHandle);
-
-            const deferred = context.newPromise();
-            pendingDeferreds.add(deferred);
-            deferred.settled.finally(() => pendingDeferreds.delete(deferred));
-
-            this.invokeAction(path, args).then(
-              (value) => {
-                if (!deferred.alive) return;
-                if (value === undefined) {
-                  deferred.resolve();
-                  return;
-                }
-                const serialized = JSON.stringify(value);
-                const handle = context.newString(serialized);
-                deferred.resolve(handle);
-                handle.dispose();
-              },
-              (err) => {
-                if (!deferred.alive) return;
-                const msg = err instanceof Error ? err.message : String(err);
-                const handle = context.newError(msg);
-                deferred.reject(handle);
-                handle.dispose();
-              },
-            );
-
-            return deferred.handle;
-          },
-        );
-        context.setProp(context.global, "__runline_invoke", actionBridge);
-        actionBridge.dispose();
-
-        const plugins = this.registry.listPlugins();
-        const pluginNames = plugins.map((p) => p.name);
-        const helpData = buildHelpData(plugins);
-        const source = buildExecutionSource(code, pluginNames, helpData);
-
-        const evaluated = context.evalCode(source, "runline-sandbox.js");
-        if (evaluated.error) {
-          const error = context.dump(evaluated.error);
-          evaluated.error.dispose();
-          return { result: null, error: formatError(error), logs };
-        }
-
-        // Set up promise tracking
-        context.setProp(context.global, "__runline_result", evaluated.value);
-        evaluated.value.dispose();
-
-        const stateResult = context.evalCode(
-          `(function(p){ var s = { v: void 0, e: void 0, settled: false };
-           var fmtErr = function(e){ if (e && typeof e === 'object') { var m = typeof e.message === 'string' ? e.message : ''; var st = typeof e.stack === 'string' ? e.stack : ''; if (m && st) return st.indexOf(m) === -1 ? m + '\\n' + st : st; if (m) return m; if (st) return st; } return String(e); };
-           p.then(function(v){ s.v = v; s.settled = true; }, function(e){ s.e = fmtErr(e); s.settled = true; }); return s; })(__runline_result)`,
-        );
-
-        if (stateResult.error) {
-          const error = context.dump(stateResult.error);
-          stateResult.error.dispose();
-          return { result: null, error: formatError(error), logs };
-        }
-
-        const stateHandle = stateResult.value;
-        try {
-          await this.drainAsync(
-            context,
-            runtime,
-            pendingDeferreds,
-            deadlineMs,
-            timeoutMs,
-          );
-
-          const settled = readProp(context, stateHandle, "settled") === true;
-          if (!settled) {
-            return {
-              result: null,
-              error: `Execution timed out after ${timeoutMs}ms`,
-              logs,
-            };
-          }
-
-          const error = readProp(context, stateHandle, "e");
-          if (error !== undefined) {
-            return { result: null, error: formatError(error), logs };
-          }
-
-          return { result: readProp(context, stateHandle, "v"), logs };
-        } finally {
-          stateHandle.dispose();
-        }
-      } finally {
-        for (const d of pendingDeferreds) {
-          if (d.alive) d.dispose();
-        }
-        pendingDeferreds.clear();
-        context.dispose();
+        worker = new Worker(source, {
+          eval: true,
+          resourceLimits: { maxOldGenerationSizeMb: memoryLimitMb },
+        });
+      } catch (err) {
+        resolve({ result: null, error: formatError(err), logs });
+        return;
       }
-    } catch (err) {
-      return {
-        result: null,
-        error: formatError(err),
-        logs,
+
+      let settled = false;
+      const finish = (r: ExecuteResult) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutTimer);
+        clearInterval(rssTimer);
+        void worker.terminate();
+        resolve(r);
       };
-    } finally {
-      runtime.dispose();
-    }
+
+      const timeoutTimer = setTimeout(() => {
+        finish({
+          result: null,
+          error: `Execution timed out after ${timeoutMs}ms`,
+          logs,
+        });
+      }, timeoutMs);
+
+      let rssTimer: ReturnType<typeof setInterval> | undefined;
+      if (shouldArmRssWatchdog()) {
+        const baselineRss = process.memoryUsage().rss;
+        rssTimer = setInterval(() => {
+          const delta = process.memoryUsage().rss - baselineRss;
+          if (delta > memoryLimitBytes + RSS_WATCHDOG_SLACK_BYTES) {
+            finish({
+              result: null,
+              error: `Memory limit exceeded (${memoryLimitMb}MB)`,
+              logs,
+            });
+          }
+        }, 100);
+        rssTimer.unref?.();
+      }
+
+      // A reply can race the worker's death; losing it is fine — the run is
+      // over either way — but it must never surface as an unhandled
+      // rejection in the host.
+      const reply = (message: InvokeReply) => {
+        if (settled) return;
+        try {
+          worker.postMessage(message);
+        } catch {
+          // worker already gone
+        }
+      };
+
+      worker.on("message", (msg: WorkerMessage) => {
+        if (settled) return;
+        if (msg.t === "log") {
+          logs.push(`[${msg.level}] ${msg.line}`);
+        } else if (msg.t === "invoke") {
+          this.invokeAction(msg.path, msg.args).then(
+            (value) => {
+              let serialized: unknown;
+              try {
+                serialized = toPlainJson(value);
+              } catch (err) {
+                reply({
+                  t: "result",
+                  id: msg.id,
+                  ok: false,
+                  error: `Action result not JSON-serializable: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
+                });
+                return;
+              }
+              reply({ t: "result", id: msg.id, ok: true, value: serialized });
+            },
+            (err) => {
+              reply({
+                t: "result",
+                id: msg.id,
+                ok: false,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            },
+          );
+        } else if (msg.t === "done") {
+          finish(
+            msg.ok
+              ? { result: msg.result, logs }
+              : { result: null, error: msg.error ?? "Unknown error", logs },
+          );
+        }
+      });
+
+      worker.on("error", (err: NodeJS.ErrnoException) => {
+        finish({
+          result: null,
+          error:
+            err.code === "ERR_WORKER_OUT_OF_MEMORY"
+              ? `Memory limit exceeded (${memoryLimitMb}MB)`
+              : formatError(err),
+          logs,
+        });
+      });
+
+      worker.on("exit", (exitCode) => {
+        finish({
+          result: null,
+          error: `Worker exited unexpectedly (code ${exitCode})`,
+          logs,
+        });
+      });
+    });
   }
 
   private async invokeAction(path: string, args: unknown): Promise<unknown> {
@@ -231,77 +257,18 @@ export class ExecutionEngine {
     };
     return applyEnvOverrides(base, plugin.connectionConfigSchema);
   }
-
-  private async drainAsync(
-    context: QuickJSContext,
-    runtime: QuickJSRuntime,
-    pendingDeferreds: ReadonlySet<QuickJSDeferredPromise>,
-    deadlineMs: number,
-    timeoutMs: number,
-  ): Promise<void> {
-    this.drainJobs(context, runtime, deadlineMs, timeoutMs);
-
-    while (pendingDeferreds.size > 0) {
-      const remainingMs = deadlineMs - Date.now();
-      if (remainingMs <= 0) {
-        throw new Error(`Execution timed out after ${timeoutMs}ms`);
-      }
-
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      try {
-        await Promise.race([
-          Promise.race([...pendingDeferreds].map((d) => d.settled)),
-          new Promise<never>((_, reject) => {
-            timer = setTimeout(
-              () =>
-                reject(new Error(`Execution timed out after ${timeoutMs}ms`)),
-              remainingMs,
-            );
-          }),
-        ]);
-      } finally {
-        if (timer) clearTimeout(timer);
-      }
-
-      this.drainJobs(context, runtime, deadlineMs, timeoutMs);
-    }
-
-    this.drainJobs(context, runtime, deadlineMs, timeoutMs);
-  }
-
-  private drainJobs(
-    context: QuickJSContext,
-    runtime: QuickJSRuntime,
-    deadlineMs: number,
-    timeoutMs: number,
-  ): void {
-    while (runtime.hasPendingJob()) {
-      if (Date.now() >= deadlineMs) {
-        throw new Error(`Execution timed out after ${timeoutMs}ms`);
-      }
-      const pending = runtime.executePendingJobs();
-      if (pending.error) {
-        const error = context.dump(pending.error);
-        pending.error.dispose();
-        throw error instanceof Error ? error : new Error(String(error));
-      }
-    }
-  }
 }
 
 // ── Helpers ──────────────────────────────────────────────
 
-function readProp(
-  context: QuickJSContext,
-  handle: QuickJSHandle,
-  key: string,
-): unknown {
-  const prop = context.getProp(handle, key);
-  try {
-    return context.dump(prop);
-  } finally {
-    prop.dispose();
-  }
+/**
+ * JSON round-trip to (a) guarantee structured-clone compatibility and
+ * (b) preserve the previous engine's value semantics, where every action
+ * result crossed a JSON boundary (Dates → ISO strings, no Maps, etc.).
+ */
+function toPlainJson(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
 }
 
 function formatError(cause: unknown): string {
@@ -318,13 +285,13 @@ function formatError(cause: unknown): string {
 }
 
 // MiniSearch UMD bundle, vendored at the package root and inlined into the
-// sandbox source. UMD attaches `MiniSearch` to globalThis in a non-CJS /
-// non-AMD env (QuickJS), so pasting the file is enough.
+// worker source. Inside the worker it is evaluated in a local scope with a
+// fresh `module`/`exports` pair so the UMD takes its CommonJS branch.
 //
 // `../../vendor/...` resolves identically from src/core/engine.ts (dev) and
 // dist/core/engine.js (published) because tsc preserves the `core/` subdir.
 // See vendor/README.md for the upgrade procedure.
-const __minisearchSource = readFileSync(
+const minisearchSource = readFileSync(
   new URL("../../vendor/minisearch.umd.js", import.meta.url),
   "utf8",
 );
@@ -347,7 +314,7 @@ function buildHelpData(plugins: PluginDef[]): Record<string, HelpEntry[]> {
   return data;
 }
 
-function buildExecutionSource(
+function buildWorkerSource(
   code: string,
   pluginNames: string[] = [],
   helpData: Record<string, HelpEntry[]> = {},
@@ -362,18 +329,68 @@ function buildExecutionSource(
     : code;
 
   const wrapped = `"use strict";
-const __invoke = __runline_invoke;
-const __log = __runline_log;
-try { delete globalThis.__runline_invoke; } catch {}
-try { delete globalThis.__runline_log; } catch {}
+const { parentPort: __port } = require("node:worker_threads");
+
+// process.exit would be runtime-divergent here: node kills the worker
+// synchronously, bun lets the completion message race the exit and can
+// report a silent undefined success. Make it a regular, catchable error.
+process.exit = (code) => {
+  throw new Error('process.exit(' + (code ?? 0) + ') is not available in the runline sandbox; return a value instead');
+};
+
+// ── host bridge ──
+let __seq = 0;
+const __pending = new Map();
+__port.on("message", (m) => {
+  if (!m || m.t !== "result") return;
+  const p = __pending.get(m.id);
+  if (!p) return;
+  __pending.delete(m.id);
+  if (m.ok) p.resolve(m.value);
+  else p.reject(new Error(m.error));
+});
+const __invoke = (path, args) => new Promise((resolve, reject) => {
+  const id = ++__seq;
+  __pending.set(id, { resolve, reject });
+  try {
+    __port.postMessage({ t: "invoke", id, path, args });
+  } catch (e) {
+    __pending.delete(id);
+    reject(e);
+  }
+});
+const __log = (level, line) => {
+  try { __port.postMessage({ t: "log", level, line }); } catch {}
+};
 
 const __fmt = (v) => {
   if (typeof v === 'string') return v;
   try { return JSON.stringify(v); } catch { return String(v); }
 };
 
-// Inlined MiniSearch UMD — attaches MiniSearch to globalThis inside the sandbox.
-${__minisearchSource}
+const __fmtErr = (e) => {
+  if (e && typeof e === 'object') {
+    const m = typeof e.message === 'string' ? e.message : '';
+    const st = typeof e.stack === 'string' ? e.stack : '';
+    if (m && st) return st.indexOf(m) === -1 ? m + '\\n' + st : st;
+    if (m) return m;
+    if (st) return st;
+  }
+  return String(e);
+};
+
+// JSON round-trip mirrors the host's toPlainJson: keeps results
+// structured-clone-safe and preserves JSON value semantics.
+const __toJson = (v) => v === undefined ? undefined : JSON.parse(JSON.stringify(v));
+
+// Inlined MiniSearch UMD, evaluated with a local module/exports so the UMD
+// takes its CommonJS branch regardless of the worker's module scope.
+const MiniSearch = (function () {
+  const module = { exports: {} };
+  const exports = module.exports;
+  ${minisearchSource}
+  return module.exports;
+})();
 
 const __help = ${JSON.stringify(helpData)};
 
@@ -385,8 +402,7 @@ const __makeProxy = (path = []) => new Proxy(() => undefined, {
   apply(_t, _this, args) {
     const p = path.join('.');
     if (!p) throw new Error('Action path missing');
-    return Promise.resolve(__invoke(p, args[0]))
-      .then((raw) => raw === undefined ? undefined : JSON.parse(raw));
+    return __invoke(p, args[0]);
   },
 });
 
@@ -408,7 +424,7 @@ const __formatSignature = (plugin, entry) => {
   return plugin + '.' + entry.action + (fields ? '({ ' + fields + ' })' : '()');
 };
 
-// Build a MiniSearch index over every action path. Indexed at sandbox
+// Build a MiniSearch index over every action path. Indexed at worker
 // startup, queried by actions.find().
 const __search = (() => {
   const docs = [];
@@ -528,7 +544,19 @@ const fetch = () => { throw new Error('fetch is disabled in runline sandbox'); }
 
 (async () => {
 ${body}
-})()`;
+})().then(
+  (v) => {
+    try {
+      __port.postMessage({ t: "done", ok: true, result: __toJson(v) });
+    } catch (e) {
+      __port.postMessage({ t: "done", ok: false, error: __fmtErr(e) });
+    }
+  },
+  (e) => {
+    __port.postMessage({ t: "done", ok: false, error: __fmtErr(e) });
+  },
+);
+`;
 
   return wrapped;
 }

--- a/packages/runline/src/tests/engine-robustness.test.ts
+++ b/packages/runline/src/tests/engine-robustness.test.ts
@@ -1,0 +1,178 @@
+// Engine robustness spec (born from GitHub #181). Implementation-agnostic:
+// these tests describe what execute() must do with multi-MB payloads,
+// memory pressure, timeouts, and process safety — not how the engine
+// achieves it.
+//
+// Every scenario runs in a spawned harness process because the bug that
+// motivated this spec was a hard process abort() — in-process it would
+// kill the test runner.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+import { shouldArmRssWatchdog } from "../core/engine.js";
+
+const harness = new URL("./helpers/engine-harness.ts", import.meta.url)
+  .pathname;
+
+function runScenario(name: string): {
+  exitCode: number | null;
+  aborted: boolean;
+  stderr: string;
+  report: Record<string, unknown> | null;
+} {
+  const r = spawnSync("bun", ["run", harness, name], {
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  const stderr = r.stderr ?? "";
+  let report: Record<string, unknown> | null = null;
+  try {
+    report = JSON.parse((r.stdout ?? "").trim());
+  } catch {
+    // no parseable report — harness died before printing
+  }
+  return {
+    exitCode: r.status,
+    // "Aborted(" is the generic wasm/emscripten abort banner; the
+    // list_empty assertion is the exact QuickJS GC failure from #181.
+    // Kept as a regression tripwire against any future wasm-based engine.
+    aborted:
+      stderr.includes("Aborted(") ||
+      stderr.includes("list_empty(&rt->gc_obj_list)"),
+    stderr,
+    report,
+  };
+}
+
+describe("engine large payloads", () => {
+  it("completes a multi-step chain with an ~11MB payload under the default 64MB limit", () => {
+    const { exitCode, aborted, report } = runScenario("chain-default");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report, "harness printed no report");
+    assert.equal(report.error, null);
+    const result = report.result as {
+      up: { id: string; bytes: number };
+      sent: { messageId: string; bytes: number };
+      row: { updatedRows: number };
+    };
+    assert.equal(result.up.id, "file_123");
+    assert.equal(result.sent.messageId, "msg_456");
+    assert.equal(result.row.updatedRows, 1);
+    // upload + send must have received the real payload, not a token
+    assert.ok(result.up.bytes > 10_000_000, "upload saw real bytes");
+    assert.equal(result.sent.bytes, result.up.bytes);
+  });
+
+  it("delivers byte-identical data to actions across the execution boundary", () => {
+    const { exitCode, aborted, report } = runScenario("integrity");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.equal(report.error, null);
+    const received = report.received as {
+      uploadSha: string;
+      uploadBytes: number;
+    };
+    assert.equal(received.uploadSha, report.expectedSha);
+    assert.equal(received.uploadBytes, report.expectedBytes);
+  });
+
+  it("exposes large payloads as plain strings inside the sandbox", () => {
+    const { exitCode, aborted, report } = runScenario("string-surface");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.equal(report.error, null);
+    const result = report.result as {
+      type: string;
+      bytes: number;
+      head: string;
+    };
+    assert.equal(result.type, "string");
+    assert.equal(result.bytes, report.expectedBytes);
+    assert.equal(result.head, report.expectedHead);
+  });
+
+  it("returns large values in the final result to the host intact", () => {
+    const { exitCode, aborted, report } = runScenario("final-result-large");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.equal(report.error, null);
+    assert.equal(report.resultBytes, report.expectedBytes);
+    assert.equal(report.resultSha, report.expectedSha);
+  });
+
+  it("fails soft on genuine sandbox OOM and stays usable afterwards", () => {
+    const { exitCode, aborted, report } = runScenario("sandbox-oom");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.ok(report.error, "OOM must surface as an execute() error");
+    assert.match(String(report.error), /memory/i);
+    // engine must survive: the next execute on the same engine works
+    assert.equal(report.afterError, null);
+    assert.equal(report.afterResult, 2);
+  });
+});
+
+describe("engine robustness", () => {
+  it("arms the RSS watchdog only where worker resourceLimits are not enforced", () => {
+    // node enforces maxOldGenerationSizeMb natively; a process-wide RSS
+    // watchdog there risks false kills from unrelated host allocations
+    // (e.g. a concurrent execute). bun ignores resourceLimits, so the
+    // watchdog is the only memory backstop.
+    assert.equal(shouldArmRssWatchdog({ node: "24.0.0" }), false);
+    assert.equal(shouldArmRssWatchdog({ node: "24.0.0", bun: "1.3.11" }), true);
+  });
+
+  it("survives an action resolving after timeout killed the worker", () => {
+    const { exitCode, aborted, report } = runScenario("timeout-inflight-action");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.match(String(report.error), /timed out/);
+    assert.deepEqual(report.unhandled, [], "unhandled rejections leaked");
+  });
+
+  it("surfaces a non-serializable action result as a catchable in-sandbox error", () => {
+    const { exitCode, aborted, report } = runScenario("circular-result");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.equal(report.error, null);
+    const result = report.result as { caught: boolean; message: string };
+    assert.equal(result.caught, true);
+    assert.match(result.message, /not JSON-serializable/);
+    assert.match(result.message, /circular|cyclic/i);
+    // host internals must not leak into sandbox-visible errors
+    assert.doesNotMatch(result.message, /engine\.ts/);
+  });
+
+  it("runs concurrent executes on one engine without interference", () => {
+    const { exitCode, aborted, report } = runScenario("concurrent");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.equal(report.aError, null);
+    assert.equal(report.bError, null);
+    assert.deepEqual(report.aResult, { tag: "a", waited: 50 });
+    assert.deepEqual(report.bResult, { tag: "b", waited: 30 });
+    assert.deepEqual(report.aLogs, ["[log] run-a"]);
+    assert.deepEqual(report.bLogs, ["[log] run-b"]);
+  });
+
+  it("turns process.exit in agent code into a clear error and stays usable", () => {
+    // Without interception this is runtime-divergent: node kills the worker
+    // synchronously (exit event), bun lets the done message race it and
+    // reports a silent undefined success.
+    const { exitCode, aborted, report } = runScenario("worker-suicide");
+    assert.equal(aborted, false, "process abort");
+    assert.equal(exitCode, 0);
+    assert.ok(report);
+    assert.match(String(report.error), /process\.exit\(7\)/);
+    assert.equal(report.afterError, null);
+    assert.equal(report.afterResult, 2);
+  });
+});

--- a/packages/runline/src/tests/engine-robustness.test.ts
+++ b/packages/runline/src/tests/engine-robustness.test.ts
@@ -128,7 +128,9 @@ describe("engine robustness", () => {
   });
 
   it("survives an action resolving after timeout killed the worker", () => {
-    const { exitCode, aborted, report } = runScenario("timeout-inflight-action");
+    const { exitCode, aborted, report } = runScenario(
+      "timeout-inflight-action",
+    );
     assert.equal(aborted, false, "process abort");
     assert.equal(exitCode, 0);
     assert.ok(report);

--- a/packages/runline/src/tests/helpers/engine-harness.ts
+++ b/packages/runline/src/tests/helpers/engine-harness.ts
@@ -1,0 +1,265 @@
+// Test harness for engine robustness scenarios (large payloads, OOM,
+// timeouts, crashes). Runs one named scenario in this process and prints a
+// JSON report to stdout. Tests spawn this file so that a hard process
+// abort or exit kills the harness, not the test runner.
+//
+// Usage: bun run engine-harness.ts <scenario>
+import { createHash } from "node:crypto";
+import { DEFAULT_CONFIG } from "../../config/types.js";
+import { ExecutionEngine } from "../../core/engine.js";
+import { createPluginAPI } from "../../plugin/api.js";
+import { PluginRegistry } from "../../plugin/registry.js";
+
+const BLOB_MB = 8;
+// ~8MB of raw bytes → ~10.7MB base64
+const base64 = Buffer.alloc(BLOB_MB * 1024 * 1024, 0xab).toString("base64");
+const base64Sha = createHash("sha256").update(base64).digest("hex");
+
+// Captures what the host-side actions actually received, so tests can
+// verify that data crossing the execution boundary arrives byte-identical.
+const received: Record<string, unknown> = {};
+
+function makeFilesPlugin() {
+  const { api, resolve } = createPluginAPI("test");
+  api.setName("files");
+  api.setVersion("0.0.0");
+
+  api.registerAction("getAttachment", {
+    description: "Returns a large base64 payload",
+    async execute() {
+      await new Promise((r) => setTimeout(r, 5));
+      return { filename: "msa.pdf", data: base64 };
+    },
+  });
+
+  api.registerAction("upload", {
+    description: "Accepts a large base64 payload",
+    async execute(input) {
+      await new Promise((r) => setTimeout(r, 5));
+      const { data } = input as { data: string };
+      received.uploadSha =
+        typeof data === "string"
+          ? createHash("sha256").update(data).digest("hex")
+          : `not-a-string:${typeof data}`;
+      received.uploadBytes = typeof data === "string" ? data.length : -1;
+      return { id: "file_123", bytes: received.uploadBytes };
+    },
+  });
+
+  api.registerAction("send", {
+    description: "Accepts a large attachment",
+    async execute(input) {
+      await new Promise((r) => setTimeout(r, 5));
+      const { attachment } = input as { attachment: string };
+      received.sendBytes =
+        typeof attachment === "string" ? attachment.length : -1;
+      return { messageId: "msg_456", bytes: received.sendBytes };
+    },
+  });
+
+  api.registerAction("append", {
+    description: "Small side effect",
+    async execute() {
+      await new Promise((r) => setTimeout(r, 5));
+      return { updatedRows: 1 };
+    },
+  });
+
+  api.registerAction("slow", {
+    description: "Sleeps for the given ms, then returns",
+    async execute(input) {
+      const { ms } = input as { ms: number };
+      await new Promise((r) => setTimeout(r, ms));
+      return { waited: ms };
+    },
+  });
+
+  api.registerAction("circular", {
+    description: "Returns a non-JSON-serializable (circular) value",
+    async execute() {
+      const obj: Record<string, unknown> = { name: "loop" };
+      obj.self = obj;
+      return obj;
+    },
+  });
+
+  return resolve();
+}
+
+function makeEngine(memoryMb = 64, timeoutMs = 30_000) {
+  const registry = new PluginRegistry();
+  registry.register(makeFilesPlugin());
+  return new ExecutionEngine(registry, {
+    ...DEFAULT_CONFIG,
+    timeoutMs,
+    memoryLimitBytes: memoryMb * 1024 * 1024,
+  });
+}
+
+type Scenario = () => Promise<Record<string, unknown>>;
+
+const scenarios: Record<string, Scenario> = {
+  // The agent's original failure: multi-step chain with a large payload,
+  // default 64MB memory limit. Must complete cleanly.
+  async "chain-default"() {
+    const engine = makeEngine(64);
+    const out = await engine.execute(`
+      const att = await files.getAttachment({ messageId: "m1" });
+      const up = await files.upload({ name: att.filename, data: att.data });
+      const sent = await files.send({ to: "x@y.z", attachment: att.data });
+      const row = await files.append({ values: [["Triple-A MSA", "May"]] });
+      return { up, sent, row };
+    `);
+    return { error: out.error ?? null, result: out.result, received };
+  },
+
+  // Integrity: the bytes the upload action receives must be byte-identical
+  // to what getAttachment produced.
+  async integrity() {
+    const engine = makeEngine(64);
+    const out = await engine.execute(`
+      const att = await files.getAttachment({ messageId: "m1" });
+      await files.upload({ name: att.filename, data: att.data });
+      return "done";
+    `);
+    return {
+      error: out.error ?? null,
+      expectedSha: base64Sha,
+      expectedBytes: base64.length,
+      received,
+    };
+  },
+
+  // Ergonomics: inside the sandbox a large payload is a plain string the
+  // agent can measure, slice, and pass around — no tokens, no proxies.
+  async "string-surface"() {
+    const engine = makeEngine(64);
+    const out = await engine.execute(`
+      const att = await files.getAttachment({ messageId: "m1" });
+      const d = att.data;
+      return { type: typeof d, bytes: d.length, head: d.slice(0, 8) };
+    `);
+    return {
+      error: out.error ?? null,
+      result: out.result,
+      expectedBytes: base64.length,
+      expectedHead: base64.slice(0, 8),
+    };
+  },
+
+  // A large value in the final return reaches the host caller intact.
+  async "final-result-large"() {
+    const engine = makeEngine(64);
+    const out = await engine.execute(`
+      const att = await files.getAttachment({ messageId: "m1" });
+      return { data: att.data };
+    `);
+    const data = (out.result as { data?: unknown } | null)?.data;
+    return {
+      error: out.error ?? null,
+      resultBytes: typeof data === "string" ? data.length : -1,
+      resultSha:
+        typeof data === "string"
+          ? createHash("sha256").update(data).digest("hex")
+          : null,
+      expectedSha: base64Sha,
+      expectedBytes: base64.length,
+    };
+  },
+
+  // An action still in flight when the run times out must not crash the
+  // host when its result arrives after the worker is gone — no unhandled
+  // rejections, no uncaught exceptions, clean timeout error.
+  async "timeout-inflight-action"() {
+    const unhandled: string[] = [];
+    process.on("unhandledRejection", (e) => unhandled.push(String(e)));
+    process.on("uncaughtException", (e) => unhandled.push(String(e)));
+    const engine = makeEngine(64, 150);
+    const out = await engine.execute(`
+      await files.slow({ ms: 1000 });
+      return "unreachable";
+    `);
+    // let the in-flight action resolve against the dead worker
+    await new Promise((r) => setTimeout(r, 1200));
+    return { error: out.error ?? null, unhandled };
+  },
+
+  // An action returning a non-JSON-serializable value must surface as a
+  // clean per-call error inside the sandbox — catchable by agent code —
+  // not a hang or a crash.
+  async "circular-result"() {
+    const engine = makeEngine(64);
+    const out = await engine.execute(`
+      try {
+        await files.circular({});
+        return { caught: false };
+      } catch (e) {
+        return { caught: true, message: e.message };
+      }
+    `);
+    return { error: out.error ?? null, result: out.result };
+  },
+
+  // Two executes on the same engine running concurrently must not
+  // interfere — separate workers, separate logs, correct results.
+  async concurrent() {
+    const engine = makeEngine(64);
+    const [a, b] = await Promise.all([
+      engine.execute(
+        `console.log("run-a"); const r = await files.slow({ ms: 50 }); return { tag: "a", waited: r.waited };`,
+      ),
+      engine.execute(
+        `console.log("run-b"); const r = await files.slow({ ms: 30 }); return { tag: "b", waited: r.waited };`,
+      ),
+    ]);
+    return {
+      aError: a.error ?? null,
+      bError: b.error ?? null,
+      aResult: a.result,
+      bResult: b.result,
+      aLogs: a.logs,
+      bLogs: b.logs,
+    };
+  },
+
+  // Agent code killing its own worker (it has the full runtime, so it can)
+  // must fail soft with a descriptive error and leave the engine usable.
+  async "worker-suicide"() {
+    const engine = makeEngine(64);
+    const out = await engine.execute(`process.exit(7);`);
+    const after = await engine.execute("return 1 + 1");
+    return {
+      error: out.error ?? null,
+      afterError: after.error ?? null,
+      afterResult: after.result,
+    };
+  },
+
+  // Sandbox code that genuinely exhausts the memory limit must fail soft:
+  // a clean error returned from execute(), no process abort, and the engine
+  // must remain usable for a subsequent run.
+  async "sandbox-oom"() {
+    const engine = makeEngine(32);
+    const out = await engine.execute(`
+      const hog = [];
+      while (true) hog.push(new Array(1e6).fill(1));
+    `);
+    const after = await engine.execute("return 1 + 1");
+    return {
+      error: out.error ?? null,
+      afterError: after.error ?? null,
+      afterResult: after.result,
+    };
+  },
+};
+
+const name = process.argv[2];
+const scenario = scenarios[name];
+if (!scenario) {
+  console.error(`Unknown scenario: ${name}`);
+  process.exit(2);
+}
+
+const report = await scenario();
+console.log(JSON.stringify(report));
+process.exit(0);


### PR DESCRIPTION
Fixes #181.

## Problem

A single `execute_actions` call chaining several heavy operations (large base64 attachments through Drive/Gmail/Sheets) aborted the whole process at teardown:

```
Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at: ../../vendor/quickjs/quickjs.c,2036,JS_FreeRuntime)
```

Worse, the abort fired *after* side effects committed, so agents couldn't tell what landed. Reproduced deterministically with stub plugins: an ~11MB base64 payload crossing the QuickJS bridge under the default 64MB wasm heap multiplies into 4+ live copies (host stringify → string handle → sandbox parse → next call's args dump), and an allocation failure mid-flight leaks handles into `gc_obj_list` → hard `abort()` in `JS_FreeRuntime`.

## Approach

The sandbox was never a security boundary — it's an ergonomic coding surface for agents, like bash. So instead of patching the wasm VM (blob tokens, size guards, abort containment were all spec'd and rejected), agent code now runs in a **`node:worker_threads` worker**:

- **Crash class eliminated** — no wasm GC, no handle lifecycle. Multi-MB payloads are plain strings agents can measure, slice, and pass around.
- **Timeout** — `worker.terminate()`, interrupts even `while(true){}`.
- **Memory** — `resourceLimits.maxOldGenerationSizeMb` under node, RSS-delta watchdog backstop under bun (which ignores resourceLimits — probe-verified). Both fail soft with a clean `Memory limit exceeded` error and the engine stays usable.
- **`process.exit` intercepted** — runtime-divergent otherwise: node kills the worker synchronously, bun races the completion message and reports a silent undefined success. Now a clear catchable error on both.
- **Non-serializable action results** — clean `Action result not JSON-serializable` error inside the sandbox, no host internals leaked.
- Fresh worker per execute; a dead worker never poisons the engine. Concurrent executes don't interfere.

Same `ExecutionEngine` API and injected surface (action proxies, `actions.list/find/describe/check`, MiniSearch, console capture). Action results still JSON round-trip to preserve value semantics. `quickjs-emscripten` removed.

## Tests

TDD'd: `engine-robustness.test.ts` + `engine-harness.ts` run every scenario in a spawned process (the original bug is a hard abort — in-process it would kill the runner), with a stderr tripwire for the exact GC assertion. Covers: the original multi-step chain, byte-identical data across the boundary, large final results, OOM fail-soft, in-flight actions resolving after timeout, circular results, concurrency, and `process.exit`.

**180/180 tests pass, tsc + biome clean.**

## Tradeoff

Agent code now has the full host runtime (`require`, `Buffer`, real network if it wants it). That's deliberate: it's bash, not a jail. `fetch` remains shadowed as policy.