### PR TITLE
[SHFT-735] Expose Projects, Issues, and Views actions

### DIFF
--- a/packages/runline-plugins/shiftLabs/src/index.ts
+++ b/packages/runline-plugins/shiftLabs/src/index.ts
@@ -1,7 +1,9 @@
 import type { RunlinePluginAPI } from "runline";
 import * as t from "typebox";
+import { registerIssueViewActions } from "./issue-views.js";
 import { registerIssueActions } from "./issues.js";
 import { registerPageActions } from "./pages.js";
+import { registerProjectActions } from "./projects.js";
 import { registerTranscriptionActions } from "./transcription.js";
 
 export default function shiftLabs(rl: RunlinePluginAPI) {
@@ -23,7 +25,9 @@ export default function shiftLabs(rl: RunlinePluginAPI) {
     }),
   );
 
+  registerProjectActions(rl);
   registerIssueActions(rl);
+  registerIssueViewActions(rl);
   registerPageActions(rl);
   registerTranscriptionActions(rl);
 }

--- a/packages/runline-plugins/shiftLabs/src/issue-views.ts
+++ b/packages/runline-plugins/shiftLabs/src/issue-views.ts
@@ -13,15 +13,23 @@ import {
 } from "./shared.js";
 
 const viewFields = {
-  name: t.String({ description: "View name" }),
-  visibility: t.Optional(enumSchema("View visibility", ISSUE_VIEW_VISIBILITY)),
+  name: t.String({ minLength: 1, maxLength: 120, description: "View name" }),
+  visibility: t.Optional(t.Literal("organization")),
   layout: t.Optional(enumSchema("View layout", ISSUE_VIEW_LAYOUT)),
-  projectId: t.Optional(t.String()),
-  rootIssueId: t.Optional(t.String()),
-  statuses: t.Optional(t.Array(enumSchema("Issue status", ISSUE_STATUS))),
-  priorities: t.Optional(t.Array(enumSchema("Issue priority", ISSUE_PRIORITY))),
-  assigneeUserIds: t.Optional(t.Array(t.String())),
-  labels: t.Optional(t.Array(t.String())),
+  projectId: t.Optional(t.String({ minLength: 1 })),
+  rootIssueId: t.Optional(t.String({ minLength: 1 })),
+  statuses: t.Optional(
+    t.Array(enumSchema("Issue status", ISSUE_STATUS), { maxItems: 5 }),
+  ),
+  priorities: t.Optional(
+    t.Array(enumSchema("Issue priority", ISSUE_PRIORITY), { maxItems: 5 }),
+  ),
+  assigneeUserIds: t.Optional(
+    t.Array(t.String({ minLength: 1 }), { maxItems: 20 }),
+  ),
+  labels: t.Optional(
+    t.Array(t.String({ minLength: 1, maxLength: 64 }), { maxItems: 20 }),
+  ),
   startAfter: t.Optional(t.String()),
   dueBefore: t.Optional(t.String()),
   blocked: t.Optional(t.Boolean()),
@@ -35,27 +43,39 @@ const viewFields = {
 };
 
 export function registerIssueViewActions(rl: RunlinePluginAPI) {
+  const listFields = {
+    visibility: t.Optional(
+      enumSchema("View visibility", ISSUE_VIEW_VISIBILITY),
+    ),
+    cursor: t.Optional(
+      t.String({ minLength: 1, description: "Next-page cursor" }),
+    ),
+    limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+  };
+
   rl.registerAction("issueView.list", {
     access: "read",
-    description: "List personal and organization Issue Views.",
-    inputSchema: t.Object({
-      visibility: t.Optional(
-        enumSchema("View visibility", ISSUE_VIEW_VISIBILITY),
-      ),
-      limit: t.Optional(t.Number({ minimum: 1, maximum: 100 })),
-    }),
+    description:
+      "List the first page of personal and organization Issue Views.",
+    inputSchema: t.Object(listFields),
     async execute(input, ctx) {
-      const params = new URLSearchParams();
-      for (const [key, value] of Object.entries(
-        (input ?? {}) as Record<string, unknown>,
-      )) {
-        if (value !== undefined) params.set(key, String(value));
-      }
       const body = await request<{ views: unknown[] }>(
         ctx,
-        `/v1/issue-views?${params}`,
+        `/v1/issue-views?${listParams(input)}`,
       );
       return body.views;
+    },
+  });
+
+  rl.registerAction("issueView.listPage", {
+    access: "read",
+    description: "List a cursor-paginated page of Issue Views.",
+    inputSchema: t.Object(listFields),
+    async execute(input, ctx) {
+      return request<{ views: unknown[]; nextCursor?: string }>(
+        ctx,
+        `/v1/issue-views?${listParams(input)}`,
+      );
     },
   });
 
@@ -75,15 +95,48 @@ export function registerIssueViewActions(rl: RunlinePluginAPI) {
 
   rl.registerAction("issueView.issues", {
     access: "read",
-    description: "Execute a saved Issue View and return matching Issues.",
-    inputSchema: t.Object({ id: t.String() }),
+    description: "Execute the first page of a saved Issue View.",
+    inputSchema: t.Object({
+      id: t.String({ minLength: 1 }),
+      limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+    }),
     async execute(input, ctx) {
-      const { id } = input as { id: string };
+      const { id, ...pagination } = input as {
+        id: string;
+        limit?: number;
+      };
       const body = await request<{ issues: unknown[] }>(
         ctx,
-        `/v1/issue-views/${pathSegment(id)}/issues`,
+        withQuery(
+          `/v1/issue-views/${pathSegment(id)}/issues`,
+          listParams(pagination),
+        ),
       );
       return body.issues;
+    },
+  });
+
+  rl.registerAction("issueView.issuesPage", {
+    access: "read",
+    description: "Execute a cursor-paginated page of a saved Issue View.",
+    inputSchema: t.Object({
+      id: t.String({ minLength: 1 }),
+      cursor: t.Optional(t.String({ minLength: 1 })),
+      limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+    }),
+    async execute(input, ctx) {
+      const { id, ...pagination } = input as {
+        id: string;
+        cursor?: string;
+        limit?: number;
+      };
+      return request<{ issues: unknown[]; nextCursor?: string }>(
+        ctx,
+        withQuery(
+          `/v1/issue-views/${pathSegment(id)}/issues`,
+          listParams(pagination),
+        ),
+      );
     },
   });
 
@@ -103,16 +156,44 @@ export function registerIssueViewActions(rl: RunlinePluginAPI) {
 
   rl.registerAction("issueView.update", {
     access: "write",
-    description: "Update a saved Issue View.",
-    inputSchema: t.Object({
-      id: t.String(),
-      ...Object.fromEntries(
-        Object.entries(viewFields).map(([key, schema]) => [
-          key,
-          key === "name" ? t.Optional(schema) : schema,
-        ]),
-      ),
-    }),
+    description:
+      "Patch a saved Issue View. Null filter values remove that filter without replacing unrelated filters.",
+    inputSchema: t.Object(
+      {
+        id: t.String({ minLength: 1 }),
+        name: t.Optional(t.String({ minLength: 1, maxLength: 120 })),
+        visibility: t.Optional(t.Literal("organization")),
+        layout: t.Optional(enumSchema("View layout", ISSUE_VIEW_LAYOUT)),
+        projectId: optionalNullableString(),
+        rootIssueId: optionalNullableString(),
+        statuses: optionalNullableArray(
+          enumSchema("Issue status", ISSUE_STATUS),
+          5,
+        ),
+        priorities: optionalNullableArray(
+          enumSchema("Issue priority", ISSUE_PRIORITY),
+          5,
+        ),
+        assigneeUserIds: optionalNullableArray(t.String({ minLength: 1 }), 20),
+        labels: optionalNullableArray(
+          t.String({ minLength: 1, maxLength: 64 }),
+          20,
+        ),
+        startAfter: optionalNullableString(),
+        dueBefore: optionalNullableString(),
+        blocked: t.Optional(t.Union([t.Boolean(), t.Null()])),
+        groupBy: t.Optional(
+          t.Union([enumSchema("View grouping", ISSUE_VIEW_GROUP), t.Null()]),
+        ),
+        sortBy: t.Optional(
+          t.Array(enumSchema("View sort", ISSUE_VIEW_SORT), {
+            minItems: 1,
+            maxItems: 3,
+          }),
+        ),
+      },
+      { minProperties: 2 },
+    ),
     async execute(input, ctx) {
       const { id, ...fields } = input as { id: string } & Record<
         string,
@@ -139,6 +220,29 @@ export function registerIssueViewActions(rl: RunlinePluginAPI) {
       return { deleted: true };
     },
   });
+}
+
+function listParams(input: unknown): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(
+    (input ?? {}) as Record<string, unknown>,
+  )) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  return params;
+}
+
+function withQuery(path: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+function optionalNullableString() {
+  return t.Optional(t.Union([t.String({ minLength: 1 }), t.Null()]));
+}
+
+function optionalNullableArray<T extends t.TSchema>(item: T, maxItems: number) {
+  return t.Optional(t.Union([t.Array(item, { maxItems }), t.Null()]));
 }
 
 function toViewBody(
@@ -174,7 +278,7 @@ function toViewBody(
     ...view,
     ...(applyDefaults
       ? {
-          visibility: view.visibility ?? "personal",
+          visibility: view.visibility ?? "organization",
           layout: view.layout ?? "list",
         }
       : {}),

--- a/packages/runline-plugins/shiftLabs/src/issue-views.ts
+++ b/packages/runline-plugins/shiftLabs/src/issue-views.ts
@@ -1,0 +1,186 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import {
+  enumSchema,
+  ISSUE_PRIORITY,
+  ISSUE_STATUS,
+  ISSUE_VIEW_GROUP,
+  ISSUE_VIEW_LAYOUT,
+  ISSUE_VIEW_SORT,
+  ISSUE_VIEW_VISIBILITY,
+  pathSegment,
+  request,
+} from "./shared.js";
+
+const viewFields = {
+  name: t.String({ description: "View name" }),
+  visibility: t.Optional(enumSchema("View visibility", ISSUE_VIEW_VISIBILITY)),
+  layout: t.Optional(enumSchema("View layout", ISSUE_VIEW_LAYOUT)),
+  projectId: t.Optional(t.String()),
+  rootIssueId: t.Optional(t.String()),
+  statuses: t.Optional(t.Array(enumSchema("Issue status", ISSUE_STATUS))),
+  priorities: t.Optional(t.Array(enumSchema("Issue priority", ISSUE_PRIORITY))),
+  assigneeUserIds: t.Optional(t.Array(t.String())),
+  labels: t.Optional(t.Array(t.String())),
+  startAfter: t.Optional(t.String()),
+  dueBefore: t.Optional(t.String()),
+  blocked: t.Optional(t.Boolean()),
+  groupBy: t.Optional(enumSchema("View grouping", ISSUE_VIEW_GROUP)),
+  sortBy: t.Optional(
+    t.Array(enumSchema("View sort", ISSUE_VIEW_SORT), {
+      minItems: 1,
+      maxItems: 3,
+    }),
+  ),
+};
+
+export function registerIssueViewActions(rl: RunlinePluginAPI) {
+  rl.registerAction("issueView.list", {
+    access: "read",
+    description: "List personal and organization Issue Views.",
+    inputSchema: t.Object({
+      visibility: t.Optional(
+        enumSchema("View visibility", ISSUE_VIEW_VISIBILITY),
+      ),
+      limit: t.Optional(t.Number({ minimum: 1, maximum: 100 })),
+    }),
+    async execute(input, ctx) {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(
+        (input ?? {}) as Record<string, unknown>,
+      )) {
+        if (value !== undefined) params.set(key, String(value));
+      }
+      const body = await request<{ views: unknown[] }>(
+        ctx,
+        `/v1/issue-views?${params}`,
+      );
+      return body.views;
+    },
+  });
+
+  rl.registerAction("issueView.get", {
+    access: "read",
+    description: "Get an Issue View by ID.",
+    inputSchema: t.Object({ id: t.String() }),
+    async execute(input, ctx) {
+      const { id } = input as { id: string };
+      const body = await request<{ view: unknown }>(
+        ctx,
+        `/v1/issue-views/${pathSegment(id)}`,
+      );
+      return body.view;
+    },
+  });
+
+  rl.registerAction("issueView.issues", {
+    access: "read",
+    description: "Execute a saved Issue View and return matching Issues.",
+    inputSchema: t.Object({ id: t.String() }),
+    async execute(input, ctx) {
+      const { id } = input as { id: string };
+      const body = await request<{ issues: unknown[] }>(
+        ctx,
+        `/v1/issue-views/${pathSegment(id)}/issues`,
+      );
+      return body.issues;
+    },
+  });
+
+  rl.registerAction("issueView.create", {
+    access: "write",
+    description:
+      "Create a bounded saved Issue query. Views never own Issue membership.",
+    inputSchema: t.Object(viewFields),
+    async execute(input, ctx) {
+      const body = await request<{ view: unknown }>(ctx, "/v1/issue-views", {
+        method: "POST",
+        body: JSON.stringify(toViewBody(input as Record<string, unknown>)),
+      });
+      return body.view;
+    },
+  });
+
+  rl.registerAction("issueView.update", {
+    access: "write",
+    description: "Update a saved Issue View.",
+    inputSchema: t.Object({
+      id: t.String(),
+      ...Object.fromEntries(
+        Object.entries(viewFields).map(([key, schema]) => [
+          key,
+          key === "name" ? t.Optional(schema) : schema,
+        ]),
+      ),
+    }),
+    async execute(input, ctx) {
+      const { id, ...fields } = input as { id: string } & Record<
+        string,
+        unknown
+      >;
+      const body = await request<{ view: unknown }>(
+        ctx,
+        `/v1/issue-views/${pathSegment(id)}`,
+        { method: "PATCH", body: JSON.stringify(toViewBody(fields, false)) },
+      );
+      return body.view;
+    },
+  });
+
+  rl.registerAction("issueView.delete", {
+    access: "write",
+    description: "Delete a saved Issue View without changing any Issues.",
+    inputSchema: t.Object({ id: t.String() }),
+    async execute(input, ctx) {
+      const { id } = input as { id: string };
+      await request<void>(ctx, `/v1/issue-views/${pathSegment(id)}`, {
+        method: "DELETE",
+      });
+      return { deleted: true };
+    },
+  });
+}
+
+function toViewBody(
+  input: Record<string, unknown>,
+  applyDefaults = true,
+): Record<string, unknown> {
+  const {
+    projectId,
+    rootIssueId,
+    statuses,
+    priorities,
+    assigneeUserIds,
+    labels,
+    startAfter,
+    dueBefore,
+    blocked,
+    ...view
+  } = input;
+  const filters = Object.fromEntries(
+    Object.entries({
+      projectId,
+      rootIssueId,
+      statuses,
+      priorities,
+      assigneeUserIds,
+      labels,
+      startAfter,
+      dueBefore,
+      blocked,
+    }).filter(([, value]) => value !== undefined),
+  );
+  return {
+    ...view,
+    ...(applyDefaults
+      ? {
+          visibility: view.visibility ?? "personal",
+          layout: view.layout ?? "list",
+        }
+      : {}),
+    ...(Object.keys(filters).length > 0 ? { filters } : {}),
+    ...(applyDefaults && view.sortBy === undefined
+      ? { sortBy: ["updatedAt"] }
+      : {}),
+  };
+}

--- a/packages/runline-plugins/shiftLabs/src/issues.ts
+++ b/packages/runline-plugins/shiftLabs/src/issues.ts
@@ -2,20 +2,21 @@ import type { RunlinePluginAPI } from "runline";
 import * as t from "typebox";
 import {
   enumSchema,
-  ISSUE_KIND,
   ISSUE_PRIORITY,
-  ISSUE_SEVERITY,
   ISSUE_SOURCE,
   ISSUE_STATUS,
+  pathSegment,
   request,
 } from "./shared.js";
 
 export function registerIssueActions(rl: RunlinePluginAPI) {
   rl.registerAction("issue.list", {
     access: "read",
-    description: "List Shift Labs issues for the API key's organization.",
+    description: "List Shift Labs Issues for the API key's organization.",
     inputSchema: t.Object({
       status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
+      projectId: t.Optional(t.String()),
+      parentIssueId: t.Optional(t.String()),
       assigneeUserId: t.Optional(t.String()),
       source: t.Optional(enumSchema("Issue source", ISSUE_SOURCE)),
       limit: t.Optional(t.Number({ description: "Max results, default 50" })),
@@ -23,7 +24,14 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     async execute(input, ctx) {
       const fields = (input ?? {}) as Record<string, unknown>;
       const params = new URLSearchParams();
-      for (const key of ["status", "assigneeUserId", "source", "limit"]) {
+      for (const key of [
+        "status",
+        "projectId",
+        "parentIssueId",
+        "assigneeUserId",
+        "source",
+        "limit",
+      ]) {
         const value = fields[key];
         if (value !== undefined) params.set(key, String(value));
       }
@@ -37,13 +45,13 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
 
   rl.registerAction("issue.get", {
     access: "read",
-    description: "Get a Shift Labs issue by ID.",
+    description: "Get a Shift Labs Issue by ID.",
     inputSchema: t.Object({ id: t.String({ description: "Issue ID" }) }),
     async execute(input, ctx) {
       const { id } = input as { id: string };
       const body = await request<{ issue: unknown }>(
         ctx,
-        `/v1/issues/${encodeURIComponent(id)}`,
+        `/v1/issues/${pathSegment(id)}`,
       );
       return body.issue;
     },
@@ -51,14 +59,22 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
 
   rl.registerAction("issue.create", {
     access: "write",
-    description: "Create a Shift Labs issue. The issue starts in triage.",
+    description:
+      "Create an Issue. Leave projectId empty for inbox work; parentIssueId requires a Project.",
     inputSchema: t.Object({
       title: t.String({ description: "Issue title" }),
       description: t.Optional(t.String({ description: "Issue description" })),
-      kind: t.Optional(enumSchema("Issue kind", ISSUE_KIND)),
+      projectId: t.Optional(t.String()),
+      parentIssueId: t.Optional(t.String()),
+      sortOrder: t.Optional(t.Number({ minimum: 0 })),
+      status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
       priority: t.Optional(enumSchema("Issue priority", ISSUE_PRIORITY)),
-      severity: t.Optional(enumSchema("Issue severity", ISSUE_SEVERITY)),
       source: t.Optional(enumSchema("Issue source", ISSUE_SOURCE)),
+      assigneeUserId: t.Optional(t.String()),
+      startAt: t.Optional(
+        t.String({ description: "ISO-8601 start timestamp" }),
+      ),
+      dueAt: t.Optional(t.String({ description: "ISO-8601 due timestamp" })),
       deploymentId: t.Optional(t.String()),
       workspaceId: t.Optional(t.String()),
       sessionId: t.Optional(t.String()),
@@ -76,9 +92,41 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     },
   });
 
+  rl.registerAction("issue.update", {
+    access: "write",
+    description:
+      "Update an Issue, including Project assignment, one-level parentage, ordering, status, dates, or assignee.",
+    inputSchema: t.Object({
+      id: t.String({ description: "Issue ID" }),
+      title: t.Optional(t.String()),
+      description: t.Optional(t.String()),
+      projectId: t.Optional(t.Union([t.String(), t.Null()])),
+      parentIssueId: t.Optional(t.Union([t.String(), t.Null()])),
+      sortOrder: t.Optional(t.Number({ minimum: 0 })),
+      status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
+      priority: t.Optional(enumSchema("Issue priority", ISSUE_PRIORITY)),
+      assigneeUserId: t.Optional(t.Union([t.String(), t.Null()])),
+      startAt: t.Optional(t.Union([t.String(), t.Null()])),
+      dueAt: t.Optional(t.Union([t.String(), t.Null()])),
+      labels: t.Optional(t.Array(t.String())),
+    }),
+    async execute(input, ctx) {
+      const { id, ...patch } = input as { id: string } & Record<
+        string,
+        unknown
+      >;
+      const body = await request<{ issue: unknown }>(
+        ctx,
+        `/v1/issues/${pathSegment(id)}`,
+        { method: "PATCH", body: JSON.stringify(patch) },
+      );
+      return body.issue;
+    },
+  });
+
   rl.registerAction("issue.comment", {
     access: "write",
-    description: "Add a comment to a Shift Labs issue.",
+    description: "Add a comment to a Shift Labs Issue.",
     inputSchema: t.Object({
       id: t.String({ description: "Issue ID" }),
       body: t.String({ description: "Comment body" }),
@@ -87,10 +135,66 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
       const { id, body } = input as { id: string; body: string };
       const response = await request<{ event: unknown }>(
         ctx,
-        `/v1/issues/${encodeURIComponent(id)}/comments`,
+        `/v1/issues/${pathSegment(id)}/comments`,
         { method: "POST", body: JSON.stringify({ body }) },
       );
       return response.event;
+    },
+  });
+
+  rl.registerAction("issue.dependency.list", {
+    access: "read",
+    description: "List blocking and blocked-by links for an Issue.",
+    inputSchema: t.Object({ id: t.String({ description: "Issue ID" }) }),
+    async execute(input, ctx) {
+      const { id } = input as { id: string };
+      const body = await request<{ dependencies: unknown[] }>(
+        ctx,
+        `/v1/issues/${pathSegment(id)}/dependencies`,
+      );
+      return body.dependencies;
+    },
+  });
+
+  rl.registerAction("issue.dependency.add", {
+    access: "write",
+    description: "Declare that one Issue blocks another Issue.",
+    inputSchema: t.Object({
+      blockedIssueId: t.String({ description: "Issue that is blocked" }),
+      blockingIssueId: t.String({ description: "Issue that blocks it" }),
+    }),
+    async execute(input, ctx) {
+      const { blockedIssueId, blockingIssueId } = input as {
+        blockedIssueId: string;
+        blockingIssueId: string;
+      };
+      const body = await request<{ dependency: unknown }>(
+        ctx,
+        `/v1/issues/${pathSegment(blockedIssueId)}/dependencies`,
+        { method: "POST", body: JSON.stringify({ blockingIssueId }) },
+      );
+      return body.dependency;
+    },
+  });
+
+  rl.registerAction("issue.dependency.remove", {
+    access: "write",
+    description: "Remove an Issue dependency link.",
+    inputSchema: t.Object({
+      issueId: t.String(),
+      dependencyId: t.String(),
+    }),
+    async execute(input, ctx) {
+      const { issueId, dependencyId } = input as {
+        issueId: string;
+        dependencyId: string;
+      };
+      await request<void>(
+        ctx,
+        `/v1/issues/${pathSegment(issueId)}/dependencies/${pathSegment(dependencyId)}`,
+        { method: "DELETE" },
+      );
+      return { removed: true };
     },
   });
 }

--- a/packages/runline-plugins/shiftLabs/src/issues.ts
+++ b/packages/runline-plugins/shiftLabs/src/issues.ts
@@ -9,44 +9,72 @@ import {
   request,
 } from "./shared.js";
 
+const issueListFields = {
+  status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
+  projectId: t.Optional(t.String({ minLength: 1 })),
+  parentIssueId: t.Optional(t.String({ minLength: 1 })),
+  assigneeUserId: t.Optional(t.String({ minLength: 1 })),
+  source: t.Optional(enumSchema("Issue source", ISSUE_SOURCE)),
+  cursor: t.Optional(
+    t.String({ minLength: 1, description: "Next-page cursor" }),
+  ),
+  limit: t.Optional(
+    t.Integer({
+      minimum: 1,
+      maximum: 100,
+      description: "Max results, default 50",
+    }),
+  ),
+};
+
+function issueListParams(input: unknown): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(
+    (input ?? {}) as Record<string, unknown>,
+  )) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  return params;
+}
+
+function withQuery(path: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
 export function registerIssueActions(rl: RunlinePluginAPI) {
   rl.registerAction("issue.list", {
     access: "read",
-    description: "List Shift Labs Issues for the API key's organization.",
-    inputSchema: t.Object({
-      status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
-      projectId: t.Optional(t.String()),
-      parentIssueId: t.Optional(t.String()),
-      assigneeUserId: t.Optional(t.String()),
-      source: t.Optional(enumSchema("Issue source", ISSUE_SOURCE)),
-      limit: t.Optional(t.Number({ description: "Max results, default 50" })),
-    }),
+    description:
+      "List the first page of Shift Labs Issues for the API key's organization.",
+    inputSchema: t.Object(issueListFields),
     async execute(input, ctx) {
-      const fields = (input ?? {}) as Record<string, unknown>;
-      const params = new URLSearchParams();
-      for (const key of [
-        "status",
-        "projectId",
-        "parentIssueId",
-        "assigneeUserId",
-        "source",
-        "limit",
-      ]) {
-        const value = fields[key];
-        if (value !== undefined) params.set(key, String(value));
-      }
       const body = await request<{ issues: unknown[] }>(
         ctx,
-        `/v1/issues?${params}`,
+        `/v1/issues?${issueListParams(input)}`,
       );
       return body.issues;
+    },
+  });
+
+  rl.registerAction("issue.listPage", {
+    access: "read",
+    description: "List a cursor-paginated page of Shift Labs Issues.",
+    inputSchema: t.Object(issueListFields),
+    async execute(input, ctx) {
+      return request<{ issues: unknown[]; nextCursor?: string }>(
+        ctx,
+        `/v1/issues?${issueListParams(input)}`,
+      );
     },
   });
 
   rl.registerAction("issue.get", {
     access: "read",
     description: "Get a Shift Labs Issue by ID.",
-    inputSchema: t.Object({ id: t.String({ description: "Issue ID" }) }),
+    inputSchema: t.Object({
+      id: t.String({ minLength: 1, description: "Issue ID" }),
+    }),
     async execute(input, ctx) {
       const { id } = input as { id: string };
       const body = await request<{ issue: unknown }>(
@@ -62,26 +90,34 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     description:
       "Create an Issue. Leave projectId empty for inbox work; parentIssueId requires a Project.",
     inputSchema: t.Object({
-      title: t.String({ description: "Issue title" }),
-      description: t.Optional(t.String({ description: "Issue description" })),
-      projectId: t.Optional(t.String()),
-      parentIssueId: t.Optional(t.String()),
-      sortOrder: t.Optional(t.Number({ minimum: 0 })),
+      title: t.String({
+        minLength: 1,
+        maxLength: 160,
+        description: "Issue title",
+      }),
+      description: t.Optional(
+        t.String({ maxLength: 20_000, description: "Issue description" }),
+      ),
+      projectId: t.Optional(t.String({ minLength: 1 })),
+      parentIssueId: t.Optional(t.String({ minLength: 1 })),
+      sortOrder: t.Optional(t.Integer({ minimum: 0 })),
       status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
       priority: t.Optional(enumSchema("Issue priority", ISSUE_PRIORITY)),
       source: t.Optional(enumSchema("Issue source", ISSUE_SOURCE)),
-      assigneeUserId: t.Optional(t.String()),
+      assigneeUserId: t.Optional(t.String({ minLength: 1 })),
       startAt: t.Optional(
         t.String({ description: "ISO-8601 start timestamp" }),
       ),
       dueAt: t.Optional(t.String({ description: "ISO-8601 due timestamp" })),
-      deploymentId: t.Optional(t.String()),
-      workspaceId: t.Optional(t.String()),
-      sessionId: t.Optional(t.String()),
-      traceId: t.Optional(t.String()),
-      fingerprint: t.Optional(t.String()),
-      labels: t.Optional(t.Array(t.String())),
-      metadata: t.Optional(t.Object({}, { description: "Issue metadata" })),
+      deploymentId: t.Optional(t.String({ minLength: 1 })),
+      workspaceId: t.Optional(t.String({ minLength: 1 })),
+      sessionId: t.Optional(t.String({ minLength: 1 })),
+      traceId: t.Optional(t.String({ minLength: 1 })),
+      fingerprint: t.Optional(t.String({ minLength: 1, maxLength: 512 })),
+      labels: t.Optional(t.Array(t.String({ minLength: 1, maxLength: 64 }))),
+      metadata: t.Optional(
+        t.Record(t.String(), t.Unknown(), { description: "Issue metadata" }),
+      ),
     }),
     async execute(input, ctx) {
       const body = await request<{ issue: unknown }>(ctx, "/v1/issues", {
@@ -96,20 +132,28 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     access: "write",
     description:
       "Update an Issue, including Project assignment, one-level parentage, ordering, status, dates, or assignee.",
-    inputSchema: t.Object({
-      id: t.String({ description: "Issue ID" }),
-      title: t.Optional(t.String()),
-      description: t.Optional(t.String()),
-      projectId: t.Optional(t.Union([t.String(), t.Null()])),
-      parentIssueId: t.Optional(t.Union([t.String(), t.Null()])),
-      sortOrder: t.Optional(t.Number({ minimum: 0 })),
-      status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
-      priority: t.Optional(enumSchema("Issue priority", ISSUE_PRIORITY)),
-      assigneeUserId: t.Optional(t.Union([t.String(), t.Null()])),
-      startAt: t.Optional(t.Union([t.String(), t.Null()])),
-      dueAt: t.Optional(t.Union([t.String(), t.Null()])),
-      labels: t.Optional(t.Array(t.String())),
-    }),
+    inputSchema: t.Object(
+      {
+        id: t.String({ minLength: 1, description: "Issue ID" }),
+        title: t.Optional(t.String({ minLength: 1, maxLength: 160 })),
+        description: t.Optional(t.String({ maxLength: 20_000 })),
+        projectId: t.Optional(t.Union([t.String({ minLength: 1 }), t.Null()])),
+        parentIssueId: t.Optional(
+          t.Union([t.String({ minLength: 1 }), t.Null()]),
+        ),
+        sortOrder: t.Optional(t.Integer({ minimum: 0 })),
+        status: t.Optional(enumSchema("Issue status", ISSUE_STATUS)),
+        priority: t.Optional(enumSchema("Issue priority", ISSUE_PRIORITY)),
+        assigneeUserId: t.Optional(
+          t.Union([t.String({ minLength: 1 }), t.Null()]),
+        ),
+        startAt: t.Optional(t.Union([t.String(), t.Null()])),
+        dueAt: t.Optional(t.Union([t.String(), t.Null()])),
+        labels: t.Optional(t.Array(t.String({ minLength: 1, maxLength: 64 }))),
+        archived: t.Optional(t.Boolean()),
+      },
+      { minProperties: 2 },
+    ),
     async execute(input, ctx) {
       const { id, ...patch } = input as { id: string } & Record<
         string,
@@ -128,8 +172,12 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     access: "write",
     description: "Add a comment to a Shift Labs Issue.",
     inputSchema: t.Object({
-      id: t.String({ description: "Issue ID" }),
-      body: t.String({ description: "Comment body" }),
+      id: t.String({ minLength: 1, description: "Issue ID" }),
+      body: t.String({
+        minLength: 1,
+        maxLength: 20_000,
+        description: "Comment body",
+      }),
     }),
     async execute(input, ctx) {
       const { id, body } = input as { id: string; body: string };
@@ -144,15 +192,45 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
 
   rl.registerAction("issue.dependency.list", {
     access: "read",
-    description: "List blocking and blocked-by links for an Issue.",
-    inputSchema: t.Object({ id: t.String({ description: "Issue ID" }) }),
+    description: "List the first page of blocking and blocked-by links.",
+    inputSchema: t.Object({
+      id: t.String({ minLength: 1, description: "Issue ID" }),
+      limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+    }),
     async execute(input, ctx) {
-      const { id } = input as { id: string };
+      const { id, ...pagination } = input as { id: string; limit?: number };
       const body = await request<{ dependencies: unknown[] }>(
         ctx,
-        `/v1/issues/${pathSegment(id)}/dependencies`,
+        withQuery(
+          `/v1/issues/${pathSegment(id)}/dependencies`,
+          issueListParams(pagination),
+        ),
       );
       return body.dependencies;
+    },
+  });
+
+  rl.registerAction("issue.dependency.listPage", {
+    access: "read",
+    description: "List a cursor-paginated page of Issue dependencies.",
+    inputSchema: t.Object({
+      id: t.String({ minLength: 1, description: "Issue ID" }),
+      cursor: t.Optional(t.String({ minLength: 1 })),
+      limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+    }),
+    async execute(input, ctx) {
+      const { id, ...pagination } = input as {
+        id: string;
+        cursor?: string;
+        limit?: number;
+      };
+      return request<{ dependencies: unknown[]; nextCursor?: string }>(
+        ctx,
+        withQuery(
+          `/v1/issues/${pathSegment(id)}/dependencies`,
+          issueListParams(pagination),
+        ),
+      );
     },
   });
 
@@ -160,8 +238,14 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     access: "write",
     description: "Declare that one Issue blocks another Issue.",
     inputSchema: t.Object({
-      blockedIssueId: t.String({ description: "Issue that is blocked" }),
-      blockingIssueId: t.String({ description: "Issue that blocks it" }),
+      blockedIssueId: t.String({
+        minLength: 1,
+        description: "Issue that is blocked",
+      }),
+      blockingIssueId: t.String({
+        minLength: 1,
+        description: "Issue that blocks it",
+      }),
     }),
     async execute(input, ctx) {
       const { blockedIssueId, blockingIssueId } = input as {
@@ -181,8 +265,8 @@ export function registerIssueActions(rl: RunlinePluginAPI) {
     access: "write",
     description: "Remove an Issue dependency link.",
     inputSchema: t.Object({
-      issueId: t.String(),
-      dependencyId: t.String(),
+      issueId: t.String({ minLength: 1 }),
+      dependencyId: t.String({ minLength: 1 }),
     }),
     async execute(input, ctx) {
       const { issueId, dependencyId } = input as {

--- a/packages/runline-plugins/shiftLabs/src/projects.ts
+++ b/packages/runline-plugins/shiftLabs/src/projects.ts
@@ -1,0 +1,97 @@
+import type { RunlinePluginAPI } from "runline";
+import * as t from "typebox";
+import { enumSchema, PROJECT_STATUS, pathSegment, request } from "./shared.js";
+
+export function registerProjectActions(rl: RunlinePluginAPI) {
+  rl.registerAction("project.list", {
+    access: "read",
+    description: "List concrete Shift Labs Projects.",
+    inputSchema: t.Object({
+      status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
+      leadUserId: t.Optional(t.String()),
+      includeArchived: t.Optional(t.Boolean()),
+      limit: t.Optional(t.Number({ minimum: 1, maximum: 100 })),
+    }),
+    async execute(input, ctx) {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(
+        (input ?? {}) as Record<string, unknown>,
+      )) {
+        if (value !== undefined) params.set(key, String(value));
+      }
+      const body = await request<{ projects: unknown[] }>(
+        ctx,
+        `/v1/projects?${params}`,
+      );
+      return body.projects;
+    },
+  });
+
+  rl.registerAction("project.get", {
+    access: "read",
+    description: "Get a Project and its derived Issue progress.",
+    inputSchema: t.Object({ id: t.String({ description: "Project ID" }) }),
+    async execute(input, ctx) {
+      const { id } = input as { id: string };
+      const [project, progress] = await Promise.all([
+        request<{ project: unknown }>(ctx, `/v1/projects/${pathSegment(id)}`),
+        request<{ progress: unknown }>(
+          ctx,
+          `/v1/projects/${pathSegment(id)}/progress`,
+        ),
+      ]);
+      return { project: project.project, progress: progress.progress };
+    },
+  });
+
+  rl.registerAction("project.create", {
+    access: "write",
+    description: "Create a concrete Project container.",
+    inputSchema: t.Object({
+      name: t.String({ description: "Project name" }),
+      description: t.Optional(t.String()),
+      status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
+      leadUserId: t.Optional(t.String()),
+      startAt: t.Optional(
+        t.String({ description: "ISO-8601 start timestamp" }),
+      ),
+      targetAt: t.Optional(
+        t.String({ description: "ISO-8601 target timestamp" }),
+      ),
+    }),
+    async execute(input, ctx) {
+      const body = await request<{ project: unknown }>(ctx, "/v1/projects", {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+      return body.project;
+    },
+  });
+
+  rl.registerAction("project.update", {
+    access: "write",
+    description: "Update Project lifecycle, ownership, dates, or content.",
+    inputSchema: t.Object({
+      id: t.String({ description: "Project ID" }),
+      name: t.Optional(t.String()),
+      description: t.Optional(t.String()),
+      status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
+      leadUserId: t.Optional(t.Union([t.String(), t.Null()])),
+      startAt: t.Optional(t.Union([t.String(), t.Null()])),
+      targetAt: t.Optional(t.Union([t.String(), t.Null()])),
+      archived: t.Optional(t.Boolean()),
+    }),
+    async execute(input, ctx) {
+      const { id, ...patch } = input as { id: string } & Record<
+        string,
+        unknown
+      >;
+      const body = await request<{ project: unknown }>(
+        ctx,
+        `/v1/projects/${pathSegment(id)}`,
+        { method: "PATCH", body: JSON.stringify(patch) },
+      );
+      return body.project;
+    },
+  });
+}

--- a/packages/runline-plugins/shiftLabs/src/projects.ts
+++ b/packages/runline-plugins/shiftLabs/src/projects.ts
@@ -2,35 +2,58 @@ import type { RunlinePluginAPI } from "runline";
 import * as t from "typebox";
 import { enumSchema, PROJECT_STATUS, pathSegment, request } from "./shared.js";
 
+const projectListFields = {
+  status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
+  leadUserId: t.Optional(t.String({ minLength: 1 })),
+  includeArchived: t.Optional(t.Boolean()),
+  cursor: t.Optional(
+    t.String({ minLength: 1, description: "Next-page cursor" }),
+  ),
+  limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+};
+
+function listParams(input: unknown): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(
+    (input ?? {}) as Record<string, unknown>,
+  )) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  return params;
+}
+
 export function registerProjectActions(rl: RunlinePluginAPI) {
   rl.registerAction("project.list", {
     access: "read",
-    description: "List concrete Shift Labs Projects.",
-    inputSchema: t.Object({
-      status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
-      leadUserId: t.Optional(t.String()),
-      includeArchived: t.Optional(t.Boolean()),
-      limit: t.Optional(t.Number({ minimum: 1, maximum: 100 })),
-    }),
+    description: "List the first page of concrete Shift Labs Projects.",
+    inputSchema: t.Object(projectListFields),
     async execute(input, ctx) {
-      const params = new URLSearchParams();
-      for (const [key, value] of Object.entries(
-        (input ?? {}) as Record<string, unknown>,
-      )) {
-        if (value !== undefined) params.set(key, String(value));
-      }
       const body = await request<{ projects: unknown[] }>(
         ctx,
-        `/v1/projects?${params}`,
+        `/v1/projects?${listParams(input)}`,
       );
       return body.projects;
+    },
+  });
+
+  rl.registerAction("project.listPage", {
+    access: "read",
+    description: "List a cursor-paginated page of concrete Projects.",
+    inputSchema: t.Object(projectListFields),
+    async execute(input, ctx) {
+      return request<{ projects: unknown[]; nextCursor?: string }>(
+        ctx,
+        `/v1/projects?${listParams(input)}`,
+      );
     },
   });
 
   rl.registerAction("project.get", {
     access: "read",
     description: "Get a Project and its derived Issue progress.",
-    inputSchema: t.Object({ id: t.String({ description: "Project ID" }) }),
+    inputSchema: t.Object({
+      id: t.String({ minLength: 1, description: "Project ID" }),
+    }),
     async execute(input, ctx) {
       const { id } = input as { id: string };
       const [project, progress] = await Promise.all([
@@ -48,10 +71,14 @@ export function registerProjectActions(rl: RunlinePluginAPI) {
     access: "write",
     description: "Create a concrete Project container.",
     inputSchema: t.Object({
-      name: t.String({ description: "Project name" }),
-      description: t.Optional(t.String()),
+      name: t.String({
+        minLength: 1,
+        maxLength: 160,
+        description: "Project name",
+      }),
+      description: t.Optional(t.String({ maxLength: 20_000 })),
       status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
-      leadUserId: t.Optional(t.String()),
+      leadUserId: t.Optional(t.String({ minLength: 1 })),
       startAt: t.Optional(
         t.String({ description: "ISO-8601 start timestamp" }),
       ),
@@ -71,16 +98,19 @@ export function registerProjectActions(rl: RunlinePluginAPI) {
   rl.registerAction("project.update", {
     access: "write",
     description: "Update Project lifecycle, ownership, dates, or content.",
-    inputSchema: t.Object({
-      id: t.String({ description: "Project ID" }),
-      name: t.Optional(t.String()),
-      description: t.Optional(t.String()),
-      status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
-      leadUserId: t.Optional(t.Union([t.String(), t.Null()])),
-      startAt: t.Optional(t.Union([t.String(), t.Null()])),
-      targetAt: t.Optional(t.Union([t.String(), t.Null()])),
-      archived: t.Optional(t.Boolean()),
-    }),
+    inputSchema: t.Object(
+      {
+        id: t.String({ minLength: 1, description: "Project ID" }),
+        name: t.Optional(t.String({ minLength: 1, maxLength: 160 })),
+        description: t.Optional(t.String({ maxLength: 20_000 })),
+        status: t.Optional(enumSchema("Project status", PROJECT_STATUS)),
+        leadUserId: t.Optional(t.Union([t.String({ minLength: 1 }), t.Null()])),
+        startAt: t.Optional(t.Union([t.String(), t.Null()])),
+        targetAt: t.Optional(t.Union([t.String(), t.Null()])),
+        archived: t.Optional(t.Boolean()),
+      },
+      { minProperties: 2 },
+    ),
     async execute(input, ctx) {
       const { id, ...patch } = input as { id: string } & Record<
         string,

--- a/packages/runline-plugins/shiftLabs/src/shared.ts
+++ b/packages/runline-plugins/shiftLabs/src/shared.ts
@@ -49,18 +49,17 @@ export function pageRenderUrl(organizationId: string, slug: string): string {
 }
 
 export const ISSUE_STATUS = [
-  "triage",
-  "open",
+  "backlog",
+  "todo",
   "in_progress",
-  "resolved",
-  "closed",
+  "done",
+  "canceled",
 ] as const;
-export const ISSUE_KIND = [
-  "bug",
-  "support",
-  "feature_request",
-  "incident",
-  "task",
+export const PROJECT_STATUS = [
+  "planned",
+  "active",
+  "completed",
+  "canceled",
 ] as const;
 export const ISSUE_PRIORITY = [
   "none",
@@ -69,13 +68,27 @@ export const ISSUE_PRIORITY = [
   "high",
   "urgent",
 ] as const;
-export const ISSUE_SEVERITY = ["info", "warning", "error", "critical"] as const;
 export const ISSUE_SOURCE = [
   "user",
   "agent",
   "system",
   "api",
   "integration",
+] as const;
+export const ISSUE_VIEW_VISIBILITY = ["personal", "organization"] as const;
+export const ISSUE_VIEW_LAYOUT = ["list", "board", "timeline"] as const;
+export const ISSUE_VIEW_GROUP = [
+  "status",
+  "assignee",
+  "priority",
+  "project",
+] as const;
+export const ISSUE_VIEW_SORT = [
+  "manual",
+  "priority",
+  "startAt",
+  "dueAt",
+  "updatedAt",
 ] as const;
 export const PAGE_STATUS = ["draft", "published", "archived"] as const;
 export const PAGE_VISIBILITY = ["org", "invited"] as const;

--- a/packages/runline/src/tests/shift-labs-plugin.test.ts
+++ b/packages/runline/src/tests/shift-labs-plugin.test.ts
@@ -13,8 +13,18 @@ const originalFetch = globalThis.fetch;
 const SHIFT_LABS_ACTIONS = [
   "issue.comment",
   "issue.create",
+  "issue.dependency.add",
+  "issue.dependency.list",
+  "issue.dependency.remove",
   "issue.get",
   "issue.list",
+  "issue.update",
+  "issueView.create",
+  "issueView.delete",
+  "issueView.get",
+  "issueView.issues",
+  "issueView.list",
+  "issueView.update",
   "page.archive",
   "page.create",
   "page.get",
@@ -25,6 +35,10 @@ const SHIFT_LABS_ACTIONS = [
   "page.share",
   "page.shares",
   "page.update",
+  "project.create",
+  "project.get",
+  "project.list",
+  "project.update",
   "transcription.artifact.list",
   "transcription.job.cancel",
   "transcription.job.get",
@@ -183,6 +197,70 @@ describe("shiftLabs plugin", () => {
         ctx(),
       ),
       { id: "issue_1", title: "Broken sync" },
+    );
+  });
+
+  it("creates Projects, nested Issues, and saved Issue Views", async () => {
+    const plugin = makeShiftLabs();
+    const project = getAction(plugin, "project.create");
+    const issue = getAction(plugin, "issue.create");
+    const view = getAction(plugin, "issueView.create");
+    const calls: Array<{ url: string; body: unknown }> = [];
+
+    mockShift((input, init) => {
+      const url = String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ url, body });
+      if (url.endsWith("/v1/projects")) return { project: { id: "project_1" } };
+      if (url.endsWith("/v1/issues")) return { issue: { id: "issue_1" } };
+      if (url.endsWith("/v1/issue-views")) return { view: { id: "view_1" } };
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    assert.deepEqual(await project.execute({ name: "Unified work" }, ctx()), {
+      id: "project_1",
+    });
+    assert.deepEqual(
+      await issue.execute(
+        {
+          title: "Sub-Issue",
+          projectId: "project_1",
+          parentIssueId: "parent_1",
+        },
+        ctx(),
+      ),
+      { id: "issue_1" },
+    );
+    assert.deepEqual(
+      await view.execute(
+        {
+          name: "Project board",
+          layout: "board",
+          projectId: "project_1",
+          groupBy: "status",
+        },
+        ctx(),
+      ),
+      { id: "view_1" },
+    );
+    assert.deepEqual(
+      calls.map((call) => call.body),
+      [
+        { name: "Unified work" },
+        {
+          title: "Sub-Issue",
+          projectId: "project_1",
+          parentIssueId: "parent_1",
+        },
+        {
+          name: "Project board",
+          visibility: "personal",
+          layout: "board",
+          filters: { projectId: "project_1" },
+          groupBy: "status",
+          sortBy: ["updatedAt"],
+        },
+      ],
     );
   });
 

--- a/packages/runline/src/tests/shift-labs-plugin.test.ts
+++ b/packages/runline/src/tests/shift-labs-plugin.test.ts
@@ -15,15 +15,19 @@ const SHIFT_LABS_ACTIONS = [
   "issue.create",
   "issue.dependency.add",
   "issue.dependency.list",
+  "issue.dependency.listPage",
   "issue.dependency.remove",
   "issue.get",
   "issue.list",
+  "issue.listPage",
   "issue.update",
   "issueView.create",
   "issueView.delete",
   "issueView.get",
   "issueView.issues",
+  "issueView.issuesPage",
   "issueView.list",
+  "issueView.listPage",
   "issueView.update",
   "page.archive",
   "page.create",
@@ -38,6 +42,7 @@ const SHIFT_LABS_ACTIONS = [
   "project.create",
   "project.get",
   "project.list",
+  "project.listPage",
   "project.update",
   "transcription.artifact.list",
   "transcription.job.cancel",
@@ -200,6 +205,64 @@ describe("shiftLabs plugin", () => {
     );
   });
 
+  it("exposes strict cursor pagination without breaking first-page list actions", async () => {
+    const plugin = makeShiftLabs();
+    const page = getAction(plugin, "issue.listPage");
+    assert.ok(page.inputSchema);
+    assert.equal(Check(page.inputSchema as never, { limit: 25 }), true);
+    assert.equal(Check(page.inputSchema as never, { limit: 2.5 }), false);
+    assert.equal(Check(page.inputSchema as never, { cursor: "" }), false);
+
+    mockShift((input) => {
+      const url = new URL(String(input));
+      assert.equal(url.pathname, "/v1/issues");
+      assert.equal(url.searchParams.get("cursor"), "next_1");
+      assert.equal(url.searchParams.get("limit"), "25");
+      return { issues: [{ id: "issue_2" }], nextCursor: "next_2" };
+    });
+
+    assert.deepEqual(
+      await page.execute({ cursor: "next_1", limit: 25 }, ctx()),
+      { issues: [{ id: "issue_2" }], nextCursor: "next_2" },
+    );
+  });
+
+  it("accepts structured Issue metadata and rejects no-op updates", () => {
+    const plugin = makeShiftLabs();
+    const create = getAction(plugin, "issue.create");
+    const update = getAction(plugin, "issue.update");
+    assert.equal(
+      Check(create.inputSchema as never, {
+        title: "Investigate",
+        metadata: { source: "monitor", attempts: 3 },
+      }),
+      true,
+    );
+    assert.equal(Check(update.inputSchema as never, { id: "issue_1" }), false);
+    assert.equal(
+      Check(update.inputSchema as never, {
+        id: "issue_1",
+        archived: true,
+      }),
+      true,
+    );
+    const createView = getAction(plugin, "issueView.create");
+    assert.equal(
+      Check(createView.inputSchema as never, {
+        name: "Shared",
+        visibility: "organization",
+      }),
+      true,
+    );
+    assert.equal(
+      Check(createView.inputSchema as never, {
+        name: "Orphaned",
+        visibility: "personal",
+      }),
+      false,
+    );
+  });
+
   it("creates Projects, nested Issues, and saved Issue Views", async () => {
     const plugin = makeShiftLabs();
     const project = getAction(plugin, "project.create");
@@ -254,7 +317,7 @@ describe("shiftLabs plugin", () => {
         },
         {
           name: "Project board",
-          visibility: "personal",
+          visibility: "organization",
           layout: "board",
           filters: { projectId: "project_1" },
           groupBy: "status",


### PR DESCRIPTION
## SHFT-735

Exposes the concrete Shift Cloud Projects, Issues, dependencies, and Issue Views work model through the first-party `shiftLabs` Runline plugin.

### Changes

- Adds `project.list/get/create/update` with derived progress on get.
- Expands `issue.*` for Project assignment, one-level parentage, canonical status/dates/assignee updates, and bounded dependency operations.
- Adds `issueView.list/get/issues/create/update/delete` with the fixed View filter/group/sort vocabulary.
- Removes Issue kind/severity from the new action contract and adopts the canonical work statuses.
- Keeps report and legacy resolve/close/reopen endpoints unexposed to agents.

### Verification

- New end-to-end request-shape tests cover Project, nested Issue, and saved View creation.
- `bun run check` passes.
- `bun run build` passes.
- Full `bun run test` passes: 268 tests.

Linear: https://linear.app/the-shift-il/issue/SHFT-735/build-projects-issues-and-views-as-the-unified-work-system
