### PR TITLE
Diagnose self-prefixed plugin action names

### DIFF
--- a/packages/runline/src/core/engine.ts
+++ b/packages/runline/src/core/engine.ts
@@ -256,9 +256,10 @@ export class ExecutionEngine {
    * teach the caller — agents read error messages and self-correct.
    */
   private selfPrefixHint(path: string): string {
+    // A dot-less miss can still be the exact-name case: plugin "ping"
+    // registering action "ping" makes the callable path "ping.ping".
     const dot = path.indexOf(".");
-    if (dot < 0) return "";
-    const pluginName = path.slice(0, dot);
+    const pluginName = dot < 0 ? path : path.slice(0, dot);
     const doubled = `${pluginName}.${path}`;
     if (!this.registry.resolveAction(doubled)) return "";
     return (

--- a/packages/runline/src/core/engine.ts
+++ b/packages/runline/src/core/engine.ts
@@ -218,7 +218,7 @@ export class ExecutionEngine {
   private async invokeAction(path: string, args: unknown): Promise<unknown> {
     const resolved = this.registry.resolveAction(path);
     if (!resolved) {
-      throw new Error(`Unknown action: ${path}`);
+      throw new Error(`Unknown action: ${path}${this.selfPrefixHint(path)}`);
     }
 
     const { plugin, action } = resolved;
@@ -246,6 +246,26 @@ export class ExecutionEngine {
     }
 
     return action.execute(args, ctx);
+  }
+
+  /**
+   * A miss on "salesforce.status" is often a plugin that registered
+   * its action name with the plugin prefix ("salesforce.status" inside
+   * plugin "salesforce"), making the real path
+   * "salesforce.salesforce.status". Detect exactly that shape and
+   * teach the caller — agents read error messages and self-correct.
+   */
+  private selfPrefixHint(path: string): string {
+    const dot = path.indexOf(".");
+    if (dot < 0) return "";
+    const pluginName = path.slice(0, dot);
+    const doubled = `${pluginName}.${path}`;
+    if (!this.registry.resolveAction(doubled)) return "";
+    return (
+      `. Did you mean "${doubled}"? Plugin "${pluginName}" registered its ` +
+      `action name with the plugin prefix ("${path}"), so the full callable ` +
+      `path is "${doubled}".`
+    );
   }
 
   private resolveConnection(plugin: PluginDef): ConnectionConfig {

--- a/packages/runline/src/plugin/api.ts
+++ b/packages/runline/src/plugin/api.ts
@@ -106,6 +106,29 @@ export function isPluginFunction(val: unknown): val is PluginFunction {
   return typeof val === "function";
 }
 
+/**
+ * Action names are plugin-relative: plugin "salesforce" registering
+ * "salesforce.status" is callable as "salesforce.salesforce.status",
+ * which is almost never what the author meant. Warn at resolve time —
+ * the earliest point where both the final plugin name and the full
+ * action list are known (setName may be called after registerAction,
+ * and object exports never go through createPluginAPI).
+ */
+function warnSelfPrefixedActions(plugin: PluginDef): void {
+  for (const action of plugin.actions) {
+    if (
+      action.name === plugin.name ||
+      action.name.startsWith(`${plugin.name}.`)
+    ) {
+      console.warn(
+        `[runline] Plugin "${plugin.name}" registered action "${action.name}", which repeats the plugin name. ` +
+          `Action names are plugin-relative, so this action is callable as "${plugin.name}.${action.name}" — ` +
+          `not "${action.name}". Rename the action to "${action.name.slice(plugin.name.length + 1) || action.name}".`,
+      );
+    }
+  }
+}
+
 export function resolvePluginExport(
   exported: PluginFunction | PluginDef,
   pluginId: string,
@@ -113,10 +136,14 @@ export function resolvePluginExport(
   if (isPluginFunction(exported)) {
     const { api, resolve } = createPluginAPI(pluginId);
     exported(api);
-    return resolve();
+    const plugin = resolve();
+    warnSelfPrefixedActions(plugin);
+    return plugin;
   }
   if (exported && typeof exported === "object" && "actions" in exported) {
-    return exported as PluginDef;
+    const plugin = exported as PluginDef;
+    warnSelfPrefixedActions(plugin);
+    return plugin;
   }
   throw new Error(
     `Invalid plugin export from "${pluginId}": expected a function or { name, actions } object`,

--- a/packages/runline/src/plugin/api.ts
+++ b/packages/runline/src/plugin/api.ts
@@ -116,16 +116,16 @@ export function isPluginFunction(val: unknown): val is PluginFunction {
  */
 function warnSelfPrefixedActions(plugin: PluginDef): void {
   for (const action of plugin.actions) {
-    if (
-      action.name === plugin.name ||
-      action.name.startsWith(`${plugin.name}.`)
-    ) {
-      console.warn(
-        `[runline] Plugin "${plugin.name}" registered action "${action.name}", which repeats the plugin name. ` +
-          `Action names are plugin-relative, so this action is callable as "${plugin.name}.${action.name}" — ` +
-          `not "${action.name}". Rename the action to "${action.name.slice(plugin.name.length + 1) || action.name}".`,
-      );
-    }
+    const prefixed = action.name.startsWith(`${plugin.name}.`);
+    if (!prefixed && action.name !== plugin.name) continue;
+    const advice = prefixed
+      ? `Rename the action to "${action.name.slice(plugin.name.length + 1)}".`
+      : "Choose an action name that does not repeat the plugin name.";
+    console.warn(
+      `[runline] Plugin "${plugin.name}" registered action "${action.name}", which repeats the plugin name. ` +
+        `Action names are plugin-relative, so this action is callable as "${plugin.name}.${action.name}" — ` +
+        `not "${action.name}". ${advice}`,
+    );
   }
 }
 

--- a/packages/runline/src/tests/self-prefixed-actions.test.ts
+++ b/packages/runline/src/tests/self-prefixed-actions.test.ts
@@ -83,7 +83,13 @@ describe("self-prefixed action names: load-time warning", () => {
     } finally {
       warn.restore();
     }
-    assert.match(warn.lines.join("\n"), /registered action "ping"/);
+    const output = warn.lines.join("\n");
+    assert.match(output, /registered action "ping"/);
+    assert.match(output, /callable as "ping\.ping"/);
+    // No slice-derived rename exists here; the advice must not
+    // suggest the name the action already has.
+    assert.match(output, /does not repeat the plugin name/);
+    assert.doesNotMatch(output, /Rename the action to/);
   });
 
   it("does not warn for ordinary relative action names", () => {
@@ -137,6 +143,22 @@ describe("self-prefixed action names: call-time hint", () => {
     const result = await engine.execute("return await salesforce.nope({})");
     assert.match(result.error ?? "", /Unknown action: salesforce\.nope/);
     assert.doesNotMatch(result.error ?? "", /Did you mean/);
+  });
+
+  it("hints on a dot-less miss when the action name equals the plugin name", async () => {
+    const registry = new PluginRegistry();
+    registry.register({
+      name: "ping",
+      version: "1.0.0",
+      actions: [{ name: "ping", execute: () => "pong" }],
+    });
+    const engine = new ExecutionEngine(registry, {
+      ...DEFAULT_CONFIG,
+      timeoutMs: 5000,
+    });
+    const result = await engine.execute("return await ping({})");
+    assert.match(result.error ?? "", /Unknown action: ping/);
+    assert.match(result.error ?? "", /Did you mean "ping\.ping"\?/);
   });
 
   it("the double-prefixed path itself still resolves and executes", async () => {

--- a/packages/runline/src/tests/self-prefixed-actions.test.ts
+++ b/packages/runline/src/tests/self-prefixed-actions.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_CONFIG } from "../config/types.js";
+import { ExecutionEngine } from "../core/engine.js";
+import { resolvePluginExport } from "../plugin/api.js";
+import { PluginRegistry } from "../plugin/registry.js";
+import type { PluginDef } from "../plugin/types.js";
+
+function captureWarn() {
+  const original = console.warn;
+  const lines: string[] = [];
+  console.warn = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  return {
+    lines,
+    restore() {
+      console.warn = original;
+    },
+  };
+}
+
+describe("self-prefixed action names: load-time warning", () => {
+  it("warns when a function export repeats the plugin name in an action", () => {
+    const warn = captureWarn();
+    try {
+      resolvePluginExport((api) => {
+        api.setName("salesforce");
+        api.registerAction("salesforce.status", { execute: () => "ok" });
+      }, "salesforce");
+    } finally {
+      warn.restore();
+    }
+    const output = warn.lines.join("\n");
+    assert.match(
+      output,
+      /Plugin "salesforce" registered action "salesforce\.status"/,
+    );
+    assert.match(output, /callable as "salesforce\.salesforce\.status"/);
+    assert.match(output, /Rename the action to "status"/);
+  });
+
+  it("warns for setName called after registerAction", () => {
+    const warn = captureWarn();
+    try {
+      resolvePluginExport((api) => {
+        api.registerAction("salesforce.status", { execute: () => "ok" });
+        api.setName("salesforce");
+      }, "fallback");
+    } finally {
+      warn.restore();
+    }
+    assert.match(warn.lines.join("\n"), /salesforce\.salesforce\.status/);
+  });
+
+  it("warns for plain PluginDef object exports", () => {
+    const warn = captureWarn();
+    try {
+      resolvePluginExport(
+        {
+          name: "hubspot",
+          version: "1.0.0",
+          actions: [{ name: "hubspot.contact.get", execute: () => null }],
+        },
+        "hubspot",
+      );
+    } finally {
+      warn.restore();
+    }
+    assert.match(
+      warn.lines.join("\n"),
+      /Plugin "hubspot" registered action "hubspot\.contact\.get"/,
+    );
+  });
+
+  it("warns when the action name equals the plugin name exactly", () => {
+    const warn = captureWarn();
+    try {
+      resolvePluginExport((api) => {
+        api.setName("ping");
+        api.registerAction("ping", { execute: () => "pong" });
+      }, "ping");
+    } finally {
+      warn.restore();
+    }
+    assert.match(warn.lines.join("\n"), /registered action "ping"/);
+  });
+
+  it("does not warn for ordinary relative action names", () => {
+    const warn = captureWarn();
+    try {
+      resolvePluginExport((api) => {
+        api.setName("salesforce");
+        api.registerAction("status", { execute: () => "ok" });
+        api.registerAction("issue.create", { execute: () => "ok" });
+        // Prefix of the plugin name, but not the plugin name itself.
+        api.registerAction("sales.report", { execute: () => "ok" });
+      }, "salesforce");
+    } finally {
+      warn.restore();
+    }
+    assert.deepEqual(warn.lines, []);
+  });
+});
+
+describe("self-prefixed action names: call-time hint", () => {
+  function makeEngine(actionName: string): ExecutionEngine {
+    const registry = new PluginRegistry();
+    const plugin: PluginDef = {
+      name: "salesforce",
+      version: "1.0.0",
+      actions: [{ name: actionName, execute: () => "ok" }],
+    };
+    registry.register(plugin);
+    return new ExecutionEngine(registry, {
+      ...DEFAULT_CONFIG,
+      timeoutMs: 5000,
+    });
+  }
+
+  it("suggests the double-prefixed path when the plugin self-prefixed its action", async () => {
+    const engine = makeEngine("salesforce.status");
+    const result = await engine.execute("return await salesforce.status({})");
+    assert.match(result.error ?? "", /Unknown action: salesforce\.status/);
+    assert.match(
+      result.error ?? "",
+      /Did you mean "salesforce\.salesforce\.status"\?/,
+    );
+    assert.match(
+      result.error ?? "",
+      /registered its action name with the plugin prefix/,
+    );
+  });
+
+  it("keeps the plain error when no double-prefixed registration exists", async () => {
+    const engine = makeEngine("status");
+    const result = await engine.execute("return await salesforce.nope({})");
+    assert.match(result.error ?? "", /Unknown action: salesforce\.nope/);
+    assert.doesNotMatch(result.error ?? "", /Did you mean/);
+  });
+
+  it("the double-prefixed path itself still resolves and executes", async () => {
+    const engine = makeEngine("salesforce.status");
+    const result = await engine.execute(
+      "return await salesforce.salesforce.status({})",
+    );
+    assert.equal(result.error, undefined, result.error);
+    assert.equal(result.result, "ok");
+  });
+});


### PR DESCRIPTION
## Problem

Action names are plugin-relative, but nothing said so. A plugin named `salesforce` registering `salesforce.status` silently becomes callable as `salesforce.salesforce.status`; callers using the intended `salesforce.status` get a bare `Unknown action` and typically misdiagnose it as an auth/connectivity failure.

## Changes

Two diagnostics, no path-semantics changes — existing double-prefixed paths keep working:

- **Load-time warning** in `resolvePluginExport` (covers both function and object exports, and `setName` called after `registerAction`): warns that the action repeats the plugin name and shows the rename.
- **Call-time hint** in `ExecutionEngine.invokeAction`: when `salesforce.status` misses but `salesforce.salesforce.status` resolves, the error explains the self-prefixed registration and names the real callable path — agents read errors and self-correct.

Worker-side `actions.describe`/`check` already fuzzy-suggest the doubled path; the host-side call error was the gap.

## Verification

- 8 new tests in `self-prefixed-actions.test.ts` (warnings for all export shapes, hinted vs plain errors, doubled path still executes)
- Full suite: 295 pass, 0 fail
- Biome clean
- No bundled plugin trips the new warning (catalog scanned)
