### PR TITLE
JSX email bodies via React Email; drop html composing inputs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,25 +45,35 @@
         "typescript": "^5.8.0",
       },
       "peerDependencies": {
+        "@react-email/components": "^1.0.12",
+        "@react-email/render": "^2.1.0",
         "playwright": "^1.57.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "sucrase": "^3.35.1",
       },
       "optionalPeers": [
+        "@react-email/components",
+        "@react-email/render",
         "playwright",
+        "react",
+        "react-dom",
+        "sucrase",
       ],
     },
     "packages/runline-plugins": {
       "name": "runline-plugins",
       "version": "0.1.0",
       "dependencies": {
+        "rrule": "^2.8.1",
+        "typebox": "^1.1.35",
+      },
+      "devDependencies": {
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.1.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "rrule": "^2.8.1",
         "sucrase": "^3.35.1",
-        "typebox": "^1.1.35",
-      },
-      "devDependencies": {
         "typescript": "^5.8.0",
       },
       "peerDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/pi-runline": {
       "name": "pi-runline",
-      "version": "0.11.2",
+      "version": "0.15.1",
       "dependencies": {
         "runline": "^0.11.2",
       },
@@ -24,7 +24,7 @@
     },
     "packages/runline": {
       "name": "runline",
-      "version": "0.11.2",
+      "version": "0.15.1",
       "bin": {
         "runline": "./dist/main.js",
       },
@@ -55,7 +55,12 @@
       "name": "runline-plugins",
       "version": "0.1.0",
       "dependencies": {
+        "@react-email/components": "^1.0.12",
+        "@react-email/render": "^2.1.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "rrule": "^2.8.1",
+        "sucrase": "^3.35.1",
         "typebox": "^1.1.35",
       },
       "devDependencies": {
@@ -159,6 +164,14 @@
 
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
 
     "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw=="],
@@ -212,6 +225,50 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@react-email/body": ["@react-email/body@0.3.0", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug=="],
+
+    "@react-email/button": ["@react-email/button@0.2.1", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A=="],
+
+    "@react-email/code-block": ["@react-email/code-block@0.2.1", "", { "dependencies": { "prismjs": "^1.30.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw=="],
+
+    "@react-email/code-inline": ["@react-email/code-inline@0.0.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA=="],
+
+    "@react-email/column": ["@react-email/column@0.0.14", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg=="],
+
+    "@react-email/components": ["@react-email/components@1.0.12", "", { "dependencies": { "@react-email/body": "0.3.0", "@react-email/button": "0.2.1", "@react-email/code-block": "0.2.1", "@react-email/code-inline": "0.0.6", "@react-email/column": "0.0.14", "@react-email/container": "0.0.16", "@react-email/font": "0.0.10", "@react-email/head": "0.0.13", "@react-email/heading": "0.0.16", "@react-email/hr": "0.0.12", "@react-email/html": "0.0.12", "@react-email/img": "0.0.12", "@react-email/link": "0.0.13", "@react-email/markdown": "0.0.18", "@react-email/preview": "0.0.14", "@react-email/render": "2.0.6", "@react-email/row": "0.0.13", "@react-email/section": "0.0.17", "@react-email/tailwind": "2.0.7", "@react-email/text": "0.1.6" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ=="],
+
+    "@react-email/container": ["@react-email/container@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ=="],
+
+    "@react-email/font": ["@react-email/font@0.0.10", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA=="],
+
+    "@react-email/head": ["@react-email/head@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog=="],
+
+    "@react-email/heading": ["@react-email/heading@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw=="],
+
+    "@react-email/hr": ["@react-email/hr@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA=="],
+
+    "@react-email/html": ["@react-email/html@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw=="],
+
+    "@react-email/img": ["@react-email/img@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ=="],
+
+    "@react-email/link": ["@react-email/link@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw=="],
+
+    "@react-email/markdown": ["@react-email/markdown@0.0.18", "", { "dependencies": { "marked": "^15.0.12" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg=="],
+
+    "@react-email/preview": ["@react-email/preview@0.0.14", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw=="],
+
+    "@react-email/render": ["@react-email/render@2.1.0", "", { "dependencies": { "entities": "^4.5.0", "html-to-text": "^9.0.5", "html5parser": "^3.0.0", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-F+zE3O6d6sW6Aj2UjvZAA17R7tJKM7kcq2mgV6k4HCT8jeLLFaVP2txMtH1lgqYFRMZ0Gxsd37q2PRyiXLXXxA=="],
+
+    "@react-email/row": ["@react-email/row@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw=="],
+
+    "@react-email/section": ["@react-email/section@0.0.17", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w=="],
+
+    "@react-email/tailwind": ["@react-email/tailwind@2.0.7", "", { "dependencies": { "tailwindcss": "^4.1.18" }, "peerDependencies": { "@react-email/body": ">=0", "@react-email/button": ">=0", "@react-email/code-block": ">=0", "@react-email/code-inline": ">=0", "@react-email/container": ">=0", "@react-email/heading": ">=0", "@react-email/hr": ">=0", "@react-email/img": ">=0", "@react-email/link": ">=0", "@react-email/preview": ">=0", "@react-email/text": ">=0", "react": "^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@react-email/body", "@react-email/button", "@react-email/code-block", "@react-email/code-inline", "@react-email/container", "@react-email/heading", "@react-email/hr", "@react-email/img", "@react-email/link", "@react-email/preview"] }, "sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA=="],
+
+    "@react-email/text": ["@react-email/text@0.1.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw=="],
+
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
     "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
 
@@ -371,15 +428,27 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -404,6 +473,8 @@
     "fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
@@ -439,6 +510,12 @@
 
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
+    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "html5parser": ["html5parser@3.0.0", "", {}, "sha512-iNpSopa+4YHX50UOk825tBy7MghmXHo/ZpLskBYN0kAr1xhH8GlIMk5bLRXcZlfP3AnLUcSuFMu8C4MdOUxA8A=="],
+
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -464,6 +541,10 @@
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "koffi": ["koffi@2.16.0", "", {}, "sha512-h/2NJueOKWd0YYycEOWDspomizgNfuOKf/V7ZE2fytvuRtHoY9Tb+y4x6GJ6pFqaVndWn9dLK+sCI14eWtu5rA=="],
+
+    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -507,19 +588,31 @@
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
+    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
+
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
+
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "pi-runline": ["pi-runline@workspace:packages/pi-runline"],
 
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
     "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
     "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
@@ -530,6 +623,10 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -544,6 +641,10 @@
     "runline-plugins": ["runline-plugins@workspace:packages/runline-plugins"],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -565,15 +666,23 @@
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -617,6 +726,8 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@react-email/components/@react-email/render": ["@react-email/render@2.0.6", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog=="],
+
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -630,6 +741,8 @@
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/packages/runline-plugins/_shared/emailJsx.ts
+++ b/packages/runline-plugins/_shared/emailJsx.ts
@@ -1,0 +1,108 @@
+/**
+ * Render agent-authored React Email JSX into wire-ready email HTML
+ * plus a plain-text alternative.
+ *
+ * Why JSX instead of hand-written HTML: email-grade HTML (table
+ * layouts, inlined styles, client quirks) is exactly what agents get
+ * wrong; @react-email/components encodes that knowledge, and agents
+ * write JSX fluently. Evaluating agent-supplied JSX adds no new risk
+ * class — runline's executor is already a coding surface.
+ *
+ * All heavy dependencies (react, sucrase, react-email) load lazily on
+ * first use so plugins that never render JSX pay nothing at startup.
+ */
+
+type Rendered = { html: string; text: string };
+
+type ReactEmailModules = {
+  React: typeof import("react");
+  components: Record<string, unknown>;
+  render: (
+    element: import("react").ReactElement,
+    options?: { plainText?: boolean },
+  ) => Promise<string>;
+  transform: typeof import("sucrase").transform;
+};
+
+let modulesPromise: Promise<ReactEmailModules> | undefined;
+
+async function loadModules(): Promise<ReactEmailModules> {
+  modulesPromise ??= Promise.all([
+    import("react"),
+    import("@react-email/components"),
+    import("@react-email/render"),
+    import("sucrase"),
+  ]).then(([react, components, renderMod, sucrase]) => ({
+    React: react.default ?? react,
+    components: components as unknown as Record<string, unknown>,
+    render: renderMod.render,
+    transform: sucrase.transform,
+  }));
+  return modulesPromise;
+}
+
+/**
+ * Components become named parameters of the evaluation function, so
+ * only exports that are valid JS identifiers (the React components —
+ * capitalized) can be exposed. Lowercase utility exports are omitted
+ * on purpose: the JSX surface is components-only.
+ */
+function componentScope(
+  components: Record<string, unknown>,
+): { names: string[]; values: unknown[] } {
+  const names: string[] = [];
+  const values: unknown[] = [];
+  for (const [key, value] of Object.entries(components)) {
+    if (!/^[A-Z][A-Za-z0-9_$]*$/.test(key)) continue;
+    names.push(key);
+    values.push(value);
+  }
+  return { names, values };
+}
+
+export async function renderEmailJsx(jsx: string): Promise<Rendered> {
+  const source = jsx.trim();
+  if (!source) throw new Error("jsx body is empty");
+  const { React, components, render, transform } = await loadModules();
+
+  let compiled: string;
+  try {
+    // Wrap as an expression statement so a bare `<Html>…</Html>` is a
+    // valid program for sucrase; the parentheses also reject
+    // statement-level code (const/if/etc.), keeping the surface to a
+    // single JSX expression.
+    compiled = transform(`__element = (${source});`, {
+      transforms: ["jsx"],
+      production: true,
+    }).code;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`jsx parse failed: ${msg}`);
+  }
+
+  const { names, values } = componentScope(components);
+  let element: unknown;
+  try {
+    const fn = new Function(
+      "React",
+      ...names,
+      `let __element; ${compiled}; return __element;`,
+    );
+    element = fn(React, ...values);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `jsx evaluation failed: ${msg}. Available components: ${names.join(", ")}`,
+    );
+  }
+
+  if (!React.isValidElement(element)) {
+    throw new Error("jsx must evaluate to a single React element");
+  }
+
+  const [html, text] = await Promise.all([
+    render(element),
+    render(element, { plainText: true }),
+  ]);
+  return { html, text };
+}

--- a/packages/runline-plugins/_shared/emailJsx.ts
+++ b/packages/runline-plugins/_shared/emailJsx.ts
@@ -8,8 +8,11 @@
  * write JSX fluently. Evaluating agent-supplied JSX adds no new risk
  * class — runline's executor is already a coding surface.
  *
- * All heavy dependencies (react, sucrase, react-email) load lazily on
- * first use so plugins that never render JSX pay nothing at startup.
+ * All heavy dependencies (react, sucrase, react-email) are optional
+ * peers of runline — like playwright for browser actions — loaded
+ * lazily on first use. Hosts that never render JSX pay nothing;
+ * hosts without the packages get an install hint instead of a
+ * module-resolution stack trace.
  */
 
 type Rendered = { html: string; text: string };
@@ -24,6 +27,11 @@ type ReactEmailModules = {
   transform: typeof import("sucrase").transform;
 };
 
+const PEER_INSTALL_HINT =
+  "jsx email bodies require optional peer packages. Install them in the host project: " +
+  "react react-dom @react-email/components @react-email/render sucrase. " +
+  "Alternatively pass `html` or `text` instead of `jsx`.";
+
 let modulesPromise: Promise<ReactEmailModules> | undefined;
 
 async function loadModules(): Promise<ReactEmailModules> {
@@ -32,12 +40,21 @@ async function loadModules(): Promise<ReactEmailModules> {
     import("@react-email/components"),
     import("@react-email/render"),
     import("sucrase"),
-  ]).then(([react, components, renderMod, sucrase]) => ({
-    React: react.default ?? react,
-    components: components as unknown as Record<string, unknown>,
-    render: renderMod.render,
-    transform: sucrase.transform,
-  }));
+  ]).then(
+    ([react, components, renderMod, sucrase]) => ({
+      React: react.default ?? react,
+      components: components as unknown as Record<string, unknown>,
+      render: renderMod.render,
+      transform: sucrase.transform,
+    }),
+    (err) => {
+      // Don't cache the failure — the host can install the peers and
+      // retry without restarting the process.
+      modulesPromise = undefined;
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`${PEER_INSTALL_HINT} (${msg})`);
+    },
+  );
   return modulesPromise;
 }
 
@@ -68,9 +85,10 @@ export async function renderEmailJsx(jsx: string): Promise<Rendered> {
   let compiled: string;
   try {
     // Wrap as an expression statement so a bare `<Html>…</Html>` is a
-    // valid program for sucrase; the parentheses also reject
-    // statement-level code (const/if/etc.), keeping the surface to a
-    // single JSX expression.
+    // valid program for sucrase. The parentheses nudge the surface
+    // toward a single expression (statement forms like `const x = 1`
+    // fail to parse) — a shape hint, not a boundary: the executor is
+    // already a coding surface, so escaping it grants nothing.
     compiled = transform(`__element = (${source});`, {
       transforms: ["jsx"],
       production: true,

--- a/packages/runline-plugins/gmail/src/index.ts
+++ b/packages/runline-plugins/gmail/src/index.ts
@@ -392,6 +392,31 @@ function normalizeAddressList(input: string | undefined): string | undefined {
 
 // ─── Reply helpers ───────────────────────────────────────────────
 
+/**
+ * Resolve text/html from an input bag that may carry `jsx`. Rendered
+ * html replaces any html (the schema forbids passing both); an
+ * explicit `text` wins over the generated fallback so every jsx email
+ * still ships multipart/alternative.
+ */
+async function resolveBody(
+  p: Record<string, unknown>,
+): Promise<{ text?: string; html?: string }> {
+  let text = p.text as string | undefined;
+  let html = p.html as string | undefined;
+  if (typeof p.jsx === "string" && p.jsx.trim()) {
+    let rendered: { html: string; text: string };
+    try {
+      rendered = await renderEmailJsx(p.jsx);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`gmail: ${msg}`);
+    }
+    html = rendered.html;
+    text ??= rendered.text;
+  }
+  return { text, html };
+}
+
 interface GmailHeader {
   name: string;
   value: string;
@@ -657,6 +682,7 @@ async function replyToMessage(
     )
     .join(", ");
 
+  const { text, html } = await resolveBody(p);
   const email: EmailInput = {
     to,
     cc: normalizeAddressList(p.cc as string | undefined),
@@ -664,8 +690,8 @@ async function replyToMessage(
     subject: subject.toLowerCase().startsWith("re:")
       ? subject
       : `Re: ${subject}`,
-    text: p.text as string | undefined,
-    html: p.html as string | undefined,
+    text,
+    html,
     inReplyTo: messageIdHeader,
     references: messageIdHeader,
     attachments: p.attachments as EmailInput["attachments"],
@@ -718,6 +744,14 @@ const Attachment = t.Object(
 );
 const Attachments = t.Array(Attachment);
 
+const Jsx = t.Optional(
+  t.String({
+    description:
+      'React Email JSX expression rendered server-side into client-safe HTML with an auto-generated plain-text alternative. Preferred over `html` for formatted emails — handles cross-client rendering (iOS Mail, Gmail, Outlook). For Hebrew/Arabic set dir on the root: `<Html dir="rtl" lang="he"><Container><Heading>שלום</Heading><Text>גוף ההודעה</Text><Button href="...">אישור</Button></Container></Html>`. Mutually exclusive with `html`.',
+  }),
+);
+const NotJsxAndHtml = { not: { required: ["jsx", "html"] } } as const;
+
 const HasMessageContent = {
   anyOf: [
     {
@@ -742,6 +776,7 @@ const HasMessageContent = {
 const ReplyFields = {
   text: t.Optional(t.String()),
   html: t.Optional(t.String()),
+  jsx: Jsx,
   cc: t.Optional(t.String()),
   bcc: t.Optional(t.String()),
   replyToSenderOnly: t.Optional(t.Boolean()),
@@ -751,13 +786,20 @@ const ReplyFields = {
 const ReplyOptions = {
   ...strict,
   ...HasMessageContent,
-  not: {
-    required: ["replyToSenderOnly", "replyToRecipientsOnly"],
-    properties: {
-      replyToSenderOnly: { const: true },
-      replyToRecipientsOnly: { const: true },
+  // JSON Schema allows one `not` per object, so both exclusions
+  // (jsx+html, senderOnly+recipientsOnly) combine under allOf.
+  allOf: [
+    NotJsxAndHtml,
+    {
+      not: {
+        required: ["replyToSenderOnly", "replyToRecipientsOnly"],
+        properties: {
+          replyToSenderOnly: { const: true },
+          replyToRecipientsOnly: { const: true },
+        },
+      },
     },
-  },
+  ],
 } as const;
 
 const ListFields = {
@@ -899,12 +941,7 @@ export default function gmail(rl: RunlinePluginAPI) {
         subject: t.String(),
         text: t.Optional(t.String({ description: "Plain body" })),
         html: t.Optional(t.String({ description: "HTML body" })),
-        jsx: t.Optional(
-          t.String({
-            description:
-              'React Email JSX expression rendered server-side into client-safe HTML with an auto-generated plain-text alternative. Preferred over `html` for formatted emails — handles cross-client rendering (iOS Mail, Gmail, Outlook). For Hebrew/Arabic set dir on the root: `<Html dir="rtl" lang="he"><Container><Heading>שלום</Heading><Text>גוף ההודעה</Text><Button href="...">אישור</Button></Container></Html>`. Mutually exclusive with `html`.',
-          }),
-        ),
+        jsx: Jsx,
         cc: t.Optional(t.String()),
         bcc: t.Optional(t.String()),
         replyTo: t.Optional(t.String()),
@@ -914,25 +951,11 @@ export default function gmail(rl: RunlinePluginAPI) {
         threadId: t.Optional(Id),
         attachments: t.Optional(Attachments),
       },
-      { ...strict, ...HasMessageContent, not: { required: ["jsx", "html"] } },
+      { ...strict, ...HasMessageContent, ...NotJsxAndHtml },
     ),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
-      let text = p.text as string | undefined;
-      let html = p.html as string | undefined;
-      if (typeof p.jsx === "string" && p.jsx.trim()) {
-        let rendered: Awaited<ReturnType<typeof renderEmailJsx>>;
-        try {
-          rendered = await renderEmailJsx(p.jsx);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          throw new Error(`gmail: ${msg}`);
-        }
-        html = rendered.html;
-        // An explicit text body wins — the generated one is a fallback
-        // so every jsx email ships multipart/alternative.
-        text ??= rendered.text;
-      }
+      const { text, html } = await resolveBody(p);
       const email: EmailInput = {
         to: normalizeAddressList(p.to as string)!,
         cc: normalizeAddressList(p.cc as string | undefined),
@@ -1244,6 +1267,7 @@ export default function gmail(rl: RunlinePluginAPI) {
         subject: t.Optional(t.String()),
         text: t.Optional(t.String()),
         html: t.Optional(t.String()),
+        jsx: Jsx,
         cc: t.Optional(t.String()),
         bcc: t.Optional(t.String()),
         replyTo: t.Optional(t.String()),
@@ -1257,12 +1281,13 @@ export default function gmail(rl: RunlinePluginAPI) {
         threadId: t.Optional(Id),
         attachments: t.Optional(Attachments),
       },
-      strict,
+      { ...strict, ...NotJsxAndHtml },
     ),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
       const from =
         (p.from as string | undefined) ?? (p.fromAlias as string | undefined);
+      const { text, html } = await resolveBody(p);
       const email: EmailInput = {
         to: normalizeAddressList(p.to as string | undefined) ?? "",
         cc: normalizeAddressList(p.cc as string | undefined),
@@ -1270,8 +1295,8 @@ export default function gmail(rl: RunlinePluginAPI) {
         replyTo: normalizeAddressList(p.replyTo as string | undefined),
         from,
         subject: (p.subject as string) ?? "",
-        text: p.text as string | undefined,
-        html: p.html as string | undefined,
+        text,
+        html,
         attachments: p.attachments as EmailInput["attachments"],
       };
 

--- a/packages/runline-plugins/gmail/src/index.ts
+++ b/packages/runline-plugins/gmail/src/index.ts
@@ -390,12 +390,13 @@ function normalizeAddressList(input: string | undefined): string | undefined {
     .join(", ");
 }
 
-// ─── Reply helpers ───────────────────────────────────────────────
+// ─── Body resolution ─────────────────────────────────────────────
 
 /**
- * Resolve the outgoing body: `jsx` renders to html with a generated
- * plain-text alternative; an explicit `text` wins over the generated
- * fallback so every jsx email still ships multipart/alternative.
+ * Resolve the outgoing body for send/reply/draft: `jsx` renders to
+ * html with a generated plain-text alternative; an explicit `text`
+ * wins over the generated fallback so every jsx email still ships
+ * multipart/alternative.
  * Composing inputs carry no `html` field — jsx is the only HTML path
  * (raw HTML embeds go through dangerouslySetInnerHTML inside jsx).
  */
@@ -417,6 +418,8 @@ async function resolveBody(
   }
   return { text, html };
 }
+
+// ─── Reply helpers ───────────────────────────────────────────────
 
 interface GmailHeader {
   name: string;
@@ -636,6 +639,10 @@ async function replyToMessage(
     );
   }
 
+  // Render before any network round-trip so malformed jsx fails
+  // without spending Gmail API calls.
+  const { text, html } = await resolveBody(p);
+
   const original = (await gmailRequest(
     ctx,
     "GET",
@@ -683,7 +690,6 @@ async function replyToMessage(
     )
     .join(", ");
 
-  const { text, html } = await resolveBody(p);
   const email: EmailInput = {
     to,
     cc: normalizeAddressList(p.cc as string | undefined),

--- a/packages/runline-plugins/gmail/src/index.ts
+++ b/packages/runline-plugins/gmail/src/index.ts
@@ -393,16 +393,17 @@ function normalizeAddressList(input: string | undefined): string | undefined {
 // ─── Reply helpers ───────────────────────────────────────────────
 
 /**
- * Resolve text/html from an input bag that may carry `jsx`. Rendered
- * html replaces any html (the schema forbids passing both); an
- * explicit `text` wins over the generated fallback so every jsx email
- * still ships multipart/alternative.
+ * Resolve the outgoing body: `jsx` renders to html with a generated
+ * plain-text alternative; an explicit `text` wins over the generated
+ * fallback so every jsx email still ships multipart/alternative.
+ * Composing inputs carry no `html` field — jsx is the only HTML path
+ * (raw HTML embeds go through dangerouslySetInnerHTML inside jsx).
  */
 async function resolveBody(
   p: Record<string, unknown>,
 ): Promise<{ text?: string; html?: string }> {
   let text = p.text as string | undefined;
-  let html = p.html as string | undefined;
+  let html: string | undefined;
   if (typeof p.jsx === "string" && p.jsx.trim()) {
     let rendered: { html: string; text: string };
     try {
@@ -747,20 +748,15 @@ const Attachments = t.Array(Attachment);
 const Jsx = t.Optional(
   t.String({
     description:
-      'React Email JSX expression rendered server-side into client-safe HTML with an auto-generated plain-text alternative. Preferred over `html` for formatted emails — handles cross-client rendering (iOS Mail, Gmail, Outlook). For Hebrew/Arabic set dir on the root: `<Html dir="rtl" lang="he"><Container><Heading>שלום</Heading><Text>גוף ההודעה</Text><Button href="...">אישור</Button></Container></Html>`. Mutually exclusive with `html`.',
+      'React Email JSX expression rendered server-side into client-safe HTML with an auto-generated plain-text alternative — handles cross-client rendering (iOS Mail, Gmail, Outlook). For Hebrew/Arabic set dir on the root: `<Html dir="rtl" lang="he"><Container><Heading>שלום</Heading><Text>גוף ההודעה</Text><Button href="...">אישור</Button></Container></Html>`. To embed pre-rendered HTML from elsewhere: `<Html><Body><div dangerouslySetInnerHTML={{ __html: theHtml }} /></Body></Html>`.',
   }),
 );
-const NotJsxAndHtml = { not: { required: ["jsx", "html"] } } as const;
 
 const HasMessageContent = {
   anyOf: [
     {
       required: ["text"],
       properties: { text: { type: "string", minLength: 1, pattern: "\\S" } },
-    },
-    {
-      required: ["html"],
-      properties: { html: { type: "string", minLength: 1, pattern: "\\S" } },
     },
     {
       required: ["jsx"],
@@ -775,7 +771,6 @@ const HasMessageContent = {
 
 const ReplyFields = {
   text: t.Optional(t.String()),
-  html: t.Optional(t.String()),
   jsx: Jsx,
   cc: t.Optional(t.String()),
   bcc: t.Optional(t.String()),
@@ -786,20 +781,13 @@ const ReplyFields = {
 const ReplyOptions = {
   ...strict,
   ...HasMessageContent,
-  // JSON Schema allows one `not` per object, so both exclusions
-  // (jsx+html, senderOnly+recipientsOnly) combine under allOf.
-  allOf: [
-    NotJsxAndHtml,
-    {
-      not: {
-        required: ["replyToSenderOnly", "replyToRecipientsOnly"],
-        properties: {
-          replyToSenderOnly: { const: true },
-          replyToRecipientsOnly: { const: true },
-        },
-      },
+  not: {
+    required: ["replyToSenderOnly", "replyToRecipientsOnly"],
+    properties: {
+      replyToSenderOnly: { const: true },
+      replyToRecipientsOnly: { const: true },
     },
-  ],
+  },
 } as const;
 
 const ListFields = {
@@ -935,13 +923,12 @@ export default function gmail(rl: RunlinePluginAPI) {
   rl.registerAction("message.send", {
     access: "write",
     description:
-      "Send an email. For formatted or RTL (Hebrew/Arabic) bodies prefer the `jsx` field (React Email, renders client-safe HTML + text fallback) over hand-written `html`.",
+      "Send an email. `text` for plain bodies; `jsx` (React Email) for formatted or RTL (Hebrew/Arabic) bodies — renders client-safe HTML with a text fallback.",
     inputSchema: t.Object(
       {
         to: NonEmptyString,
         subject: t.String(),
         text: t.Optional(t.String({ description: "Plain body" })),
-        html: t.Optional(t.String({ description: "HTML body" })),
         jsx: Jsx,
         cc: t.Optional(t.String()),
         bcc: t.Optional(t.String()),
@@ -952,7 +939,7 @@ export default function gmail(rl: RunlinePluginAPI) {
         threadId: t.Optional(Id),
         attachments: t.Optional(Attachments),
       },
-      { ...strict, ...HasMessageContent, ...NotJsxAndHtml },
+      { ...strict, ...HasMessageContent },
     ),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
@@ -977,7 +964,7 @@ export default function gmail(rl: RunlinePluginAPI) {
   rl.registerAction("message.reply", {
     access: "write",
     description:
-      "Reply to a message, preserving threadId and In-Reply-To/References headers. Formatted bodies: prefer `jsx` over `html`.",
+      "Reply to a message, preserving threadId and In-Reply-To/References headers. `text` for plain bodies; `jsx` (React Email) for formatted ones.",
     inputSchema: t.Object({ messageId: Id, ...ReplyFields }, ReplyOptions),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
@@ -1238,7 +1225,7 @@ export default function gmail(rl: RunlinePluginAPI) {
   rl.registerAction("thread.reply", {
     access: "write",
     description:
-      "Reply to the last message in a thread (convenience wrapper over message.reply). Formatted bodies: prefer `jsx` over `html`.",
+      "Reply to the last message in a thread (convenience wrapper over message.reply). `text` for plain bodies; `jsx` (React Email) for formatted ones.",
     inputSchema: t.Object({ id: Id, ...ReplyFields }, ReplyOptions),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
@@ -1262,13 +1249,12 @@ export default function gmail(rl: RunlinePluginAPI) {
   rl.registerAction("draft.create", {
     access: "write",
     description:
-      "Create a draft. Formatted bodies: prefer `jsx` over `html` (React Email).",
+      "Create a draft. `text` for plain bodies; `jsx` (React Email) for formatted ones.",
     inputSchema: t.Object(
       {
         to: t.Optional(t.String()),
         subject: t.Optional(t.String()),
         text: t.Optional(t.String()),
-        html: t.Optional(t.String()),
         jsx: Jsx,
         cc: t.Optional(t.String()),
         bcc: t.Optional(t.String()),
@@ -1283,7 +1269,7 @@ export default function gmail(rl: RunlinePluginAPI) {
         threadId: t.Optional(Id),
         attachments: t.Optional(Attachments),
       },
-      { ...strict, ...NotJsxAndHtml },
+      strict,
     ),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;

--- a/packages/runline-plugins/gmail/src/index.ts
+++ b/packages/runline-plugins/gmail/src/index.ts
@@ -934,7 +934,8 @@ export default function gmail(rl: RunlinePluginAPI) {
 
   rl.registerAction("message.send", {
     access: "write",
-    description: "Send an email",
+    description:
+      "Send an email. For formatted or RTL (Hebrew/Arabic) bodies prefer the `jsx` field (React Email, renders client-safe HTML + text fallback) over hand-written `html`.",
     inputSchema: t.Object(
       {
         to: NonEmptyString,
@@ -976,7 +977,7 @@ export default function gmail(rl: RunlinePluginAPI) {
   rl.registerAction("message.reply", {
     access: "write",
     description:
-      "Reply to a message, preserving threadId and In-Reply-To/References headers",
+      "Reply to a message, preserving threadId and In-Reply-To/References headers. Formatted bodies: prefer `jsx` over `html`.",
     inputSchema: t.Object({ messageId: Id, ...ReplyFields }, ReplyOptions),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
@@ -1237,7 +1238,7 @@ export default function gmail(rl: RunlinePluginAPI) {
   rl.registerAction("thread.reply", {
     access: "write",
     description:
-      "Reply to the last message in a thread (convenience wrapper over message.reply)",
+      "Reply to the last message in a thread (convenience wrapper over message.reply). Formatted bodies: prefer `jsx` over `html`.",
     inputSchema: t.Object({ id: Id, ...ReplyFields }, ReplyOptions),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
@@ -1260,7 +1261,8 @@ export default function gmail(rl: RunlinePluginAPI) {
 
   rl.registerAction("draft.create", {
     access: "write",
-    description: "Create a draft",
+    description:
+      "Create a draft. Formatted bodies: prefer `jsx` over `html` (React Email).",
     inputSchema: t.Object(
       {
         to: t.Optional(t.String()),

--- a/packages/runline-plugins/gmail/src/index.ts
+++ b/packages/runline-plugins/gmail/src/index.ts
@@ -23,6 +23,7 @@
 
 import type { ActionContext, RunlinePluginAPI } from "runline";
 import * as t from "typebox";
+import { renderEmailJsx } from "../../_shared/emailJsx.js";
 import { googleAccessToken } from "../../_shared/googleAuth.js";
 import {
   GoogleTimestamp,
@@ -728,6 +729,10 @@ const HasMessageContent = {
       properties: { html: { type: "string", minLength: 1, pattern: "\\S" } },
     },
     {
+      required: ["jsx"],
+      properties: { jsx: { type: "string", minLength: 1, pattern: "\\S" } },
+    },
+    {
       required: ["attachments"],
       properties: { attachments: { type: "array", minItems: 1 } },
     },
@@ -894,6 +899,12 @@ export default function gmail(rl: RunlinePluginAPI) {
         subject: t.String(),
         text: t.Optional(t.String({ description: "Plain body" })),
         html: t.Optional(t.String({ description: "HTML body" })),
+        jsx: t.Optional(
+          t.String({
+            description:
+              'React Email JSX expression rendered server-side into client-safe HTML with an auto-generated plain-text alternative. Preferred over `html` for formatted emails — handles cross-client rendering (iOS Mail, Gmail, Outlook). For Hebrew/Arabic set dir on the root: `<Html dir="rtl" lang="he"><Container><Heading>שלום</Heading><Text>גוף ההודעה</Text><Button href="...">אישור</Button></Container></Html>`. Mutually exclusive with `html`.',
+          }),
+        ),
         cc: t.Optional(t.String()),
         bcc: t.Optional(t.String()),
         replyTo: t.Optional(t.String()),
@@ -903,10 +914,25 @@ export default function gmail(rl: RunlinePluginAPI) {
         threadId: t.Optional(Id),
         attachments: t.Optional(Attachments),
       },
-      { ...strict, ...HasMessageContent },
+      { ...strict, ...HasMessageContent, not: { required: ["jsx", "html"] } },
     ),
     async execute(input, ctx) {
       const p = (input ?? {}) as Record<string, unknown>;
+      let text = p.text as string | undefined;
+      let html = p.html as string | undefined;
+      if (typeof p.jsx === "string" && p.jsx.trim()) {
+        let rendered: Awaited<ReturnType<typeof renderEmailJsx>>;
+        try {
+          rendered = await renderEmailJsx(p.jsx);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new Error(`gmail: ${msg}`);
+        }
+        html = rendered.html;
+        // An explicit text body wins — the generated one is a fallback
+        // so every jsx email ships multipart/alternative.
+        text ??= rendered.text;
+      }
       const email: EmailInput = {
         to: normalizeAddressList(p.to as string)!,
         cc: normalizeAddressList(p.cc as string | undefined),
@@ -914,8 +940,8 @@ export default function gmail(rl: RunlinePluginAPI) {
         replyTo: normalizeAddressList(p.replyTo as string | undefined),
         from: p.from as string | undefined,
         subject: (p.subject as string) ?? "",
-        text: p.text as string | undefined,
-        html: p.html as string | undefined,
+        text,
+        html,
         attachments: p.attachments as EmailInput["attachments"],
       };
       const body: Record<string, unknown> = { raw: encodeEmail(email) };

--- a/packages/runline-plugins/package.json
+++ b/packages/runline-plugins/package.json
@@ -8,18 +8,18 @@
     "build": "tsc --noCheck"
   },
   "devDependencies": {
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.1.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "sucrase": "^3.35.1",
     "typescript": "^5.8.0"
   },
   "peerDependencies": {
     "runline": "*"
   },
   "dependencies": {
-    "@react-email/components": "^1.0.12",
-    "@react-email/render": "^2.1.0",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
     "rrule": "^2.8.1",
-    "sucrase": "^3.35.1",
     "typebox": "^1.1.35"
   }
 }

--- a/packages/runline-plugins/package.json
+++ b/packages/runline-plugins/package.json
@@ -14,7 +14,12 @@
     "runline": "*"
   },
   "dependencies": {
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.1.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "rrule": "^2.8.1",
+    "sucrase": "^3.35.1",
     "typebox": "^1.1.35"
   }
 }

--- a/packages/runline/package.json
+++ b/packages/runline/package.json
@@ -63,10 +63,30 @@
     "typescript": "^5.8.0"
   },
   "peerDependencies": {
-    "playwright": "^1.57.0"
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.1.0",
+    "playwright": "^1.57.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "sucrase": "^3.35.1"
   },
   "peerDependenciesMeta": {
+    "@react-email/components": {
+      "optional": true
+    },
+    "@react-email/render": {
+      "optional": true
+    },
     "playwright": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "sucrase": {
       "optional": true
     }
   },

--- a/packages/runline/src/tests/gmail-jsx.test.ts
+++ b/packages/runline/src/tests/gmail-jsx.test.ts
@@ -54,9 +54,7 @@ describe("renderEmailJsx", () => {
     assert.match(text, /https:\/\/example\.com\/confirm/);
   });
 
-  it("explicit text is preserved; generated text is only a fallback", async () => {
-    // Covered at the plugin level: execute uses `text ??= rendered.text`.
-    // Here assert the renderer always produces a non-empty fallback.
+  it("always produces a non-empty text fallback", async () => {
     const { text } = await renderEmailJsx("<Text>hello</Text>");
     assert.equal(text.trim(), "hello");
   });

--- a/packages/runline/src/tests/gmail-jsx.test.ts
+++ b/packages/runline/src/tests/gmail-jsx.test.ts
@@ -7,9 +7,15 @@ import gmail from "../../../runline-plugins/gmail/src/index.js";
 import { Runline } from "../sdk.js";
 
 const gmailActions = Runline.create({ plugins: [gmail] }).actions();
-const sendSchema = gmailActions.find((e) => e.action === "message.send")
-  ?.inputSchema as TSchema;
-assert.ok(sendSchema, "missing input schema for gmail.message.send");
+
+function schemaFor(action: string): TSchema {
+  const schema = gmailActions.find((e) => e.action === action)
+    ?.inputSchema as TSchema;
+  assert.ok(schema, `missing input schema for gmail.${action}`);
+  return schema;
+}
+
+const sendSchema = schemaFor("message.send");
 
 const HEBREW_JSX = `<Html dir="rtl" lang="he">
   <Container>
@@ -39,6 +45,44 @@ describe("gmail message.send jsx schema", () => {
 
   it("rejects whitespace-only jsx as the sole body", () => {
     assert.ok(!Check(sendSchema, { to: "a@b.com", subject: "s", jsx: "  " }));
+  });
+});
+
+describe("gmail jsx across reply and draft actions", () => {
+  it("message.reply and thread.reply accept a jsx-only body", () => {
+    assert.ok(
+      Check(schemaFor("message.reply"), { messageId: "m1", jsx: "<Html />" }),
+    );
+    assert.ok(Check(schemaFor("thread.reply"), { id: "t1", jsx: "<Html />" }));
+  });
+
+  it("reply actions reject jsx together with html", () => {
+    assert.ok(
+      !Check(schemaFor("message.reply"), {
+        messageId: "m1",
+        jsx: "<Html />",
+        html: "<p>x</p>",
+      }),
+    );
+  });
+
+  it("reply actions still reject both reply-scope flags", () => {
+    assert.ok(
+      !Check(schemaFor("message.reply"), {
+        messageId: "m1",
+        jsx: "<Html />",
+        replyToSenderOnly: true,
+        replyToRecipientsOnly: true,
+      }),
+    );
+  });
+
+  it("draft.create accepts jsx and rejects jsx together with html", () => {
+    const draft = schemaFor("draft.create");
+    assert.ok(Check(draft, { to: "a@b.com", jsx: "<Html />" }));
+    assert.ok(
+      !Check(draft, { to: "a@b.com", jsx: "<Html />", html: "<p>x</p>" }),
+    );
   });
 });
 

--- a/packages/runline/src/tests/gmail-jsx.test.ts
+++ b/packages/runline/src/tests/gmail-jsx.test.ts
@@ -32,14 +32,9 @@ describe("gmail message.send jsx schema", () => {
     );
   });
 
-  it("rejects jsx together with html", () => {
+  it("rejects the removed html field", () => {
     assert.ok(
-      !Check(sendSchema, {
-        to: "a@b.com",
-        subject: "s",
-        jsx: "<Html />",
-        html: "<p>x</p>",
-      }),
+      !Check(sendSchema, { to: "a@b.com", subject: "s", html: "<p>x</p>" }),
     );
   });
 
@@ -56,11 +51,10 @@ describe("gmail jsx across reply and draft actions", () => {
     assert.ok(Check(schemaFor("thread.reply"), { id: "t1", jsx: "<Html />" }));
   });
 
-  it("reply actions reject jsx together with html", () => {
+  it("reply actions reject the removed html field", () => {
     assert.ok(
       !Check(schemaFor("message.reply"), {
         messageId: "m1",
-        jsx: "<Html />",
         html: "<p>x</p>",
       }),
     );
@@ -77,12 +71,10 @@ describe("gmail jsx across reply and draft actions", () => {
     );
   });
 
-  it("draft.create accepts jsx and rejects jsx together with html", () => {
+  it("draft.create accepts jsx and rejects the removed html field", () => {
     const draft = schemaFor("draft.create");
     assert.ok(Check(draft, { to: "a@b.com", jsx: "<Html />" }));
-    assert.ok(
-      !Check(draft, { to: "a@b.com", jsx: "<Html />", html: "<p>x</p>" }),
-    );
+    assert.ok(!Check(draft, { to: "a@b.com", html: "<p>x</p>" }));
   });
 });
 
@@ -96,6 +88,16 @@ describe("renderEmailJsx", () => {
     assert.match(html, /שלום דנה/);
     assert.match(text, /שלום דנה/);
     assert.match(text, /https:\/\/example\.com\/confirm/);
+  });
+
+  it("supports the documented raw-HTML escape hatch", async () => {
+    // Pins the exact shape promised in the `jsx` field description —
+    // a div is required because react-email's Body owns its children.
+    const raw = '<p dir="rtl">שלום</p>';
+    const { html } = await renderEmailJsx(
+      `<Html><Body><div dangerouslySetInnerHTML={{ __html: ${JSON.stringify(raw)} }} /></Body></Html>`,
+    );
+    assert.ok(html.includes(raw));
   });
 
   it("always produces a non-empty text fallback", async () => {

--- a/packages/runline/src/tests/gmail-jsx.test.ts
+++ b/packages/runline/src/tests/gmail-jsx.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { TSchema } from "typebox";
+import { Check } from "typebox/value";
+import { renderEmailJsx } from "../../../runline-plugins/_shared/emailJsx.js";
+import gmail from "../../../runline-plugins/gmail/src/index.js";
+import { Runline } from "../sdk.js";
+
+const gmailActions = Runline.create({ plugins: [gmail] }).actions();
+const sendSchema = gmailActions.find((e) => e.action === "message.send")
+  ?.inputSchema as TSchema;
+assert.ok(sendSchema, "missing input schema for gmail.message.send");
+
+const HEBREW_JSX = `<Html dir="rtl" lang="he">
+  <Container>
+    <Heading>שלום דנה</Heading>
+    <Text>הפגישה נקבעה ליום שלישי ב-14:00.</Text>
+    <Button href="https://example.com/confirm">אישור הגעה</Button>
+  </Container>
+</Html>`;
+
+describe("gmail message.send jsx schema", () => {
+  it("accepts a jsx-only body", () => {
+    assert.ok(
+      Check(sendSchema, { to: "a@b.com", subject: "s", jsx: "<Html />" }),
+    );
+  });
+
+  it("rejects jsx together with html", () => {
+    assert.ok(
+      !Check(sendSchema, {
+        to: "a@b.com",
+        subject: "s",
+        jsx: "<Html />",
+        html: "<p>x</p>",
+      }),
+    );
+  });
+
+  it("rejects whitespace-only jsx as the sole body", () => {
+    assert.ok(!Check(sendSchema, { to: "a@b.com", subject: "s", jsx: "  " }));
+  });
+});
+
+describe("renderEmailJsx", () => {
+  it("renders RTL Hebrew into client-safe HTML with a text fallback", async () => {
+    const { html, text } = await renderEmailJsx(HEBREW_JSX);
+    assert.ok(html.startsWith("<!DOCTYPE"));
+    assert.match(html, /<html dir="rtl" lang="he">/);
+    // React Email's table layout is the cross-client consistency story.
+    assert.match(html, /<table[^>]*role="presentation"/);
+    assert.match(html, /שלום דנה/);
+    assert.match(text, /שלום דנה/);
+    assert.match(text, /https:\/\/example\.com\/confirm/);
+  });
+
+  it("explicit text is preserved; generated text is only a fallback", async () => {
+    // Covered at the plugin level: execute uses `text ??= rendered.text`.
+    // Here assert the renderer always produces a non-empty fallback.
+    const { text } = await renderEmailJsx("<Text>hello</Text>");
+    assert.equal(text.trim(), "hello");
+  });
+
+  it("fails loudly on malformed jsx", async () => {
+    await assert.rejects(
+      renderEmailJsx("<Html><Unclosed></Html>"),
+      /jsx (parse|evaluation) failed/,
+    );
+  });
+
+  it("rejects statement-level code", async () => {
+    await assert.rejects(renderEmailJsx("const x = 1"), /jsx parse failed/);
+  });
+
+  it("names available components when one is unknown", async () => {
+    await assert.rejects(
+      renderEmailJsx("<Bogus />"),
+      (err: Error) =>
+        /jsx evaluation failed: Bogus is not defined/.test(err.message) &&
+        /Available components: .*Button.*/.test(err.message),
+    );
+  });
+
+  it("rejects non-element results", async () => {
+    await assert.rejects(
+      renderEmailJsx('"just a string"'),
+      /must evaluate to a single React element/,
+    );
+  });
+
+  it("rejects empty input", async () => {
+    await assert.rejects(renderEmailJsx("   "), /jsx body is empty/);
+  });
+});

--- a/packages/runline/src/tests/gmail-plugin.test.ts
+++ b/packages/runline/src/tests/gmail-plugin.test.ts
@@ -218,7 +218,7 @@ describe("gmail plugin TypeBox schemas", () => {
     }
   });
 
-  it("accepts text, HTML, and attachment-only messages", () => {
+  it("accepts text, jsx, and attachment-only messages", () => {
     assert.equal(
       accepts("message.send", {
         to: "recipient@example.com",
@@ -230,8 +230,8 @@ describe("gmail plugin TypeBox schemas", () => {
     assert.equal(
       accepts("message.send", {
         to: "recipient@example.com",
-        subject: "HTML",
-        html: "<p>hello</p>",
+        subject: "JSX",
+        jsx: "<Html />",
       }),
       true,
     );
@@ -272,8 +272,8 @@ describe("gmail plugin TypeBox schemas", () => {
     assert.equal(accepts("message.send", { ...base, content: "hello" }), false);
     assert.equal(accepts("message.send", { ...base, text: "" }), false);
     assert.equal(accepts("message.send", { ...base, text: "   " }), false);
-    assert.equal(accepts("message.send", { ...base, html: "" }), false);
-    assert.equal(accepts("message.send", { ...base, html: "\n\t" }), false);
+    // html was removed in favor of jsx; the strict schema rejects it.
+    assert.equal(accepts("message.send", { ...base, html: "<p>x</p>" }), false);
     assert.equal(accepts("message.send", { ...base, attachments: [] }), false);
   });
 
@@ -326,7 +326,7 @@ describe("gmail plugin TypeBox schemas", () => {
     ] as const) {
       const base = { [idField]: "id-1" };
       assert.equal(accepts(action, { ...base, text: "reply" }), true);
-      assert.equal(accepts(action, { ...base, html: "<p>reply</p>" }), true);
+      assert.equal(accepts(action, { ...base, jsx: "<Html />" }), true);
       assert.equal(
         accepts(action, {
           ...base,


### PR DESCRIPTION
## JSX email bodies (React Email)

Gmail's composing actions (`message.send`, `message.reply`, `thread.reply`, `draft.create`) now take a `jsx` field: a React Email JSX expression rendered server-side into client-safe, table-based HTML with an auto-generated plain-text alternative (multipart/alternative for free). RTL is declarative — `<Html dir="rtl" lang="he">`.

**Breaking:** the `html` composing input is removed. Hand-written email HTML is the root cause of blank-body, broken-RTL, and cross-client rendering failures; everything it did, `jsx` does correctly. The strict schemas reject `html` loudly, so callers self-correct from the error. Raw-HTML embeds remain possible via the documented `dangerouslySetInnerHTML` escape hatch inside jsx. Reading (`message.get` etc.) still returns `html` of received mail.

## Mechanics

- `_shared/emailJsx.ts` — sucrase-transpiles the expression, evaluates with capitalized `@react-email/components` exports in scope, renders html + text. ~200ms cold (lazy import, once per process), ~2ms warm.
- **Optional peers**, following the playwright precedent: `react`, `react-dom`, `@react-email/components`, `@react-email/render`, `sucrase`. Hosts without them get an install hint at first `jsx` use; failed loads aren't cached, so install-and-retry works without a restart.
- Errors teach: parse failures with position, unknown components list the available catalog, non-element results rejected, empty bodies rejected.
- Reply renders jsx before any Gmail API round-trip — malformed jsx costs zero API calls.
- Action + field descriptions surface the jsx preference at `actions.find` and `actions.describe` time, with a worked Hebrew RTL example.

## Verification

- 15 new tests: schema contracts across all four actions (jsx accepted, `html` rejected, whitespace-only rejected, reply-flag exclusivity preserved), RTL render, text fallback, escape-hatch shape, full error taxonomy
- Full suite: 311 pass, 0 fail; build + Biome clean
