### PR TITLE
feat(linear): expose cycle archive and the team-wide cycle delete (SHFT-489)

### DIFF
--- a/packages/runline-plugins/linear/src/cycles.ts
+++ b/packages/runline-plugins/linear/src/cycles.ts
@@ -100,4 +100,55 @@ export function registerCycleActions(rl: RunlinePluginAPI) {
       return (data.cycleUpdate as Record<string, unknown>)?.cycle;
     },
   });
+  // Archive is the only way to remove a single cycle: Linear has no
+  // per-cycle delete mutation. Issues are unlinked from the cycle first,
+  // they are not archived with it.
+  rl.registerAction("cycle.archive", {
+    access: "write",
+    description:
+      "Archive one cycle. Issues assigned to it are unlinked from the cycle first, not archived. This is the per-cycle removal; Linear has no single-cycle delete.",
+    inputSchema: t.Object({
+      id: t.String({ description: "The identifier of the cycle to archive" }),
+    }),
+    async execute(input, ctx) {
+      requireUnscoped(ctx, "cycles.*");
+      const { id } = input as { id: string };
+      const data = await gql(
+        key(ctx),
+        `mutation($id: String!) { cycleArchive(id: $id) { success } }`,
+        { id },
+      );
+      return data.cycleArchive;
+    },
+  });
+
+  // Deliberately NOT named cycle.delete.
+  //
+  // Linear's teamCyclesDelete takes a *team* id and wipes every cycle that
+  // team has, disabling the cycles feature entirely. Exposing it as
+  // `cycle.delete({ id })` would read as "delete this one cycle" and let an
+  // agent destroy a team's whole cycle history by analogy with every other
+  // `*.delete` action in this plugin. The name and the parameter both say
+  // team, and the description leads with the blast radius.
+  rl.registerAction("team.cyclesDeleteAll", {
+    access: "write",
+    description:
+      "DESTRUCTIVE: delete ALL cycle data for a team and disable the cycles feature. Removes every cycle and its issue associations, not just one. To remove a single cycle use cycle.archive.",
+    inputSchema: t.Object({
+      teamId: t.String({
+        description:
+          "The identifier of the TEAM whose cycles will all be deleted",
+      }),
+    }),
+    async execute(input, ctx) {
+      requireUnscoped(ctx, "cycles.*");
+      const { teamId } = input as { teamId: string };
+      const data = await gql(
+        key(ctx),
+        `mutation($id: String!) { teamCyclesDelete(id: $id) { success } }`,
+        { id: teamId },
+      );
+      return data.teamCyclesDelete;
+    },
+  });
 }

--- a/packages/runline/src/tests/linear-plugin.test.ts
+++ b/packages/runline/src/tests/linear-plugin.test.ts
@@ -18,6 +18,7 @@ const LINEAR_ACTIONS = [
   "comment.get",
   "comment.list",
   "comment.update",
+  "cycle.archive",
   "cycle.create",
   "cycle.get",
   "cycle.list",
@@ -73,6 +74,7 @@ const LINEAR_ACTIONS = [
   "state.list",
   "state.update",
   "team.create",
+  "team.cyclesDeleteAll",
   "team.get",
   "team.list",
   "team.members",
@@ -263,6 +265,66 @@ describe("linear plugin comment actions", () => {
     const result = await action.execute({ id: "comment-1" }, ctx());
 
     assert.deepEqual(result, { success: true });
+  });
+});
+
+describe("linear plugin cycle actions", () => {
+  it("cycle.archive calls Linear's cycleArchive mutation", async () => {
+    const action = getAction(makeLinear(), "cycle.archive");
+
+    mockLinear((body) => {
+      assert.match(body.query, /cycleArchive\(id: \$id\)/);
+      assert.deepEqual(body.variables, { id: "cycle-1" });
+      return { cycleArchive: { success: true } };
+    });
+
+    const result = await action.execute({ id: "cycle-1" }, ctx());
+
+    assert.deepEqual(result, { success: true });
+  });
+
+  it("cycle.archive requires the cycle id", () => {
+    const action = getAction(makeLinear(), "cycle.archive");
+    assert.ok(isTypedInputSchema(action.inputSchema));
+    assert.equal(
+      validateTypedInput(action.inputSchema, {}).ok,
+      false,
+      "archiving without an id must be rejected",
+    );
+    assert.equal(validateTypedInput(action.inputSchema, { id: "c1" }).ok, true);
+  });
+
+  it("team.cyclesDeleteAll passes the TEAM id to teamCyclesDelete", async () => {
+    // Linear's teamCyclesDelete takes a team id and wipes every cycle that
+    // team has. The action must not be reachable under a name or parameter
+    // that reads as a single-cycle delete.
+    const action = getAction(makeLinear(), "team.cyclesDeleteAll");
+
+    mockLinear((body) => {
+      assert.match(body.query, /teamCyclesDelete\(id: \$id\)/);
+      assert.deepEqual(body.variables, { id: "team-1" });
+      return { teamCyclesDelete: { success: true } };
+    });
+
+    const result = await action.execute({ teamId: "team-1" }, ctx());
+
+    assert.deepEqual(result, { success: true });
+  });
+
+  it("the destructive team-wide delete is not exposed as cycle.delete", () => {
+    const plugin = makeLinear();
+    const names = plugin.actions.map((a) => a.name);
+    assert.ok(
+      !names.includes("cycle.delete"),
+      "cycle.delete would read as removing one cycle while deleting a team's entire cycle history",
+    );
+    const action = getAction(plugin, "team.cyclesDeleteAll");
+    assert.match(String(action.description), /^DESTRUCTIVE:/);
+    assert.ok(
+      isTypedInputSchema(action.inputSchema) &&
+        "teamId" in (action.inputSchema.properties ?? {}),
+      "the parameter must be named teamId so the blast radius is obvious",
+    );
   });
 });
 


### PR DESCRIPTION
Closes SHFT-489. Removing a Linear cycle previously required dropping to raw GraphQL.

## `cycle.archive`

Wraps `cycleArchive`. This is the **only per-cycle removal Linear offers** — there is no single-cycle delete mutation. The description says so, and records that assigned issues are *unlinked* from the cycle rather than archived with it (straight from the schema description).

## The delete half — implemented differently from the ticket, on purpose

The ticket suggested `linear.cycle.delete({ cycleId })` backed by `teamCyclesDelete`. Schema introspection against the live API says that's wrong:

```
cycleArchive      "Archives a cycle. All issues currently assigned to the cycle
                   are unlinked from it before archiving."      args: id  (the cycle)

teamCyclesDelete  "Deletes all cycle data for a team, disabling the cycles
                   feature. This removes all cycles and their issue
                   associations."                               args: id  (the TEAM)
```

`teamCyclesDelete` takes a **team** id and wipes every cycle that team has ever had, turning the feature off. Named `cycle.delete({ cycleId })` it would read as "delete this one cycle" — consistent with `comment.delete`, `attachment.delete`, `initiative.delete`, `issue.delete`, all of which take the id of the single thing they destroy. An agent following that pattern would erase a team's entire cycle history believing it removed one cycle.

So it ships as **`team.cyclesDeleteAll({ teamId })`**: action name, parameter name, and a description opening with `DESTRUCTIVE:` all state the blast radius, and it points at `cycle.archive` for the single-cycle case.

## Tests

Four new, following the existing `mockLinear` pattern:

- `cycle.archive` calls `cycleArchive` with the right variables and returns `{ success }`
- `cycle.archive` rejects a call with no id
- `team.cyclesDeleteAll` passes the **team** id through to `teamCyclesDelete`
- **`cycle.delete` is never registered** — so the misleading name can't reappear by accident — plus assertions that the description leads with `DESTRUCTIVE:` and the parameter is `teamId`

`375 pass / 0 fail`, build clean, biome clean across 112 files.

## Note on the acceptance criteria

The ticket asks the action to "return success and the archived/deleted cycle metadata". Both mutations return only `{ success }` in Linear's schema — there is no cycle payload on either — so these return `{ success: true }`, matching every other archive/delete action in this plugin.
