### PR TITLE
actions.check: validate nested shapes with the executor's own validator

### DIFF
--- a/packages/runline/src/core/engine.ts
+++ b/packages/runline/src/core/engine.ts
@@ -16,6 +16,7 @@ import type {
   ConnectionConfig,
   HelpInput,
   PluginDef,
+  TypedInputSchema,
 } from "../plugin/types.js";
 
 export interface ExecuteResult {
@@ -640,11 +641,30 @@ const ferrosearchPath = createRequire(import.meta.url).resolve(
   "@shift-labs/ferrosearch",
 );
 
+// typebox ships ESM only; require() of an .mjs works everywhere runline
+// runs (bun, and node since 22.12's require(esm)). Resolved host-side
+// for the same reason as ferrosearch: eval'd worker code gets a
+// cwd-relative require, so a bare specifier would resolve against the
+// caller's cwd instead of runline's own node_modules.
+const typeboxValuePath = createRequire(import.meta.url).resolve(
+  "typebox/value",
+);
+
 interface HelpEntry {
   action: string;
   access?: "read" | "write";
   description?: string;
   inputs: Record<string, HelpInput>;
+  /**
+   * The action's raw typed schema, when it has one. This is what
+   * `actions.check` validates against inside the worker — the same
+   * schema the host validates before execute, so preflight and
+   * execution cannot disagree (SHFT-1187). The flattened `inputs`
+   * cannot serve: it truncates deep nesting and carries no
+   * additional-properties rules. TypeBox schemas are plain JSON, so
+   * they survive the stringify into the worker source.
+   */
+  schema?: TypedInputSchema;
 }
 
 function buildHelpData(plugins: PluginDef[]): Record<string, HelpEntry[]> {
@@ -655,6 +675,7 @@ function buildHelpData(plugins: PluginDef[]): Record<string, HelpEntry[]> {
       access: a.access,
       description: a.description,
       inputs: helpInputs(a.inputSchema),
+      ...(isTypedInputSchema(a.inputSchema) ? { schema: a.inputSchema } : {}),
     }));
   }
   return data;
@@ -790,6 +811,9 @@ const __toJson = (v) => v === undefined ? undefined : JSON.parse(JSON.stringify(
 // also means an index built by agent code is invisible to that limit.
 const { FerroSearch } = require(${JSON.stringify(ferrosearchPath)});
 
+// The host's own validator, for actions.check on typed schemas.
+const { Check: __schemaCheck, Errors: __schemaErrors } = require(${JSON.stringify(typeboxValuePath)});
+
 const __help = ${JSON.stringify(helpData)};
 
 const __makeProxy = (path = []) => new Proxy(() => undefined, {
@@ -849,6 +873,82 @@ const __search = (() => {
   return index;
 })();
 
+// instancePath "/members/0/externalId" → ["members", "0", "externalId"],
+// with JSON-pointer escapes (~1 for /, ~0 for ~) undone per part.
+const __pointerParts = (instancePath) =>
+  String(instancePath || '').split('/').filter((p) => p.length)
+    .map((p) => p.replace(/~1/g, '/').replace(/~0/g, '~'));
+
+// ["members", "0", "externalId"] → "members[0].externalId"
+const __fieldPath = (instancePath, prop) => {
+  const parts = __pointerParts(instancePath);
+  if (prop !== undefined) parts.push(String(prop));
+  let out = '';
+  for (const part of parts) {
+    if (/^\\d+$/.test(part)) out += '[' + part + ']';
+    else out += out ? '.' + part : part;
+  }
+  return out;
+};
+
+const __valueAt = (root, instancePath) => {
+  let v = root;
+  for (const part of __pointerParts(instancePath)) {
+    if (v == null) return undefined;
+    v = v[part];
+  }
+  return v;
+};
+
+const __valueType = (v) => v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v;
+
+// Deep validation for typed schemas (SHFT-1187): the same Check/Errors
+// the host runs before execute, on the same schema, so the preflight
+// verdict and the execution verdict cannot diverge. The familiar
+// missing/unknown/typeErrors buckets are derived from the validator's
+// structured errors — keyword and params, never message parsing — and
+// the errors array carries each raw "<path> <message>" line exactly as
+// a rejected execution would report it. Grouping type errors by instance
+// path keeps a failed union one typeError instead of one per branch.
+const __checkTyped = (entry, provided, signature) => {
+  if (__schemaCheck(entry.schema, provided)) {
+    return { ok: true, missing: [], unknown: [], typeErrors: [], errors: [], signature };
+  }
+  const missing = [];
+  const unknown = [];
+  const errors = [];
+  const byPath = new Map();
+  for (const err of __schemaErrors(entry.schema, provided)) {
+    errors.push((err.instancePath || '/') + ' ' + err.message);
+    const params = err.params || {};
+    if (err.keyword === 'required') {
+      for (const prop of params.requiredProperties || []) missing.push(__fieldPath(err.instancePath, prop));
+    } else if (err.keyword === 'additionalProperties') {
+      for (const prop of params.additionalProperties || []) unknown.push(__fieldPath(err.instancePath, prop));
+    } else {
+      const group = byPath.get(err.instancePath) || [];
+      group.push(err);
+      byPath.set(err.instancePath, group);
+    }
+  }
+  const typeErrors = [];
+  for (const [instancePath, group] of byPath) {
+    const field = __fieldPath(instancePath) || '(input)';
+    const value = __valueAt(provided, instancePath);
+    const consts = group.filter((e) => e.keyword === 'const' && 'allowedValue' in (e.params || {}));
+    const typeErr = group.find((e) => e.keyword === 'type' && (e.params || {}).type);
+    if (consts.length) {
+      // A union of literals: the branches ARE the allowed values.
+      typeErrors.push({ field, expected: consts.map((e) => String(e.params.allowedValue)).join(' | '), actual: __fmt(value) });
+    } else if (typeErr) {
+      typeErrors.push({ field, expected: String(typeErr.params.type), actual: __valueType(value) });
+    } else {
+      typeErrors.push({ field, expected: group[0].message, actual: __fmt(value) });
+    }
+  }
+  return { ok: false, missing, unknown, typeErrors, errors, signature };
+};
+
 const __actionsApi = {
   list(plugin) {
     const paths = Object.keys(__index);
@@ -887,6 +987,13 @@ const __actionsApi = {
       const near = __actionsApi.find(path, 3).map((n) => n.path);
       return { ok: false, error: 'Unknown action: ' + path, suggestions: near };
     }
+    const signature = __formatSignature(hit.plugin, hit.entry);
+    if (hit.entry.schema) {
+      // Mirror the host's normalizeActionInput: a check with no args is
+      // a call with an empty argument set; anything else — null, a
+      // scalar — is validated as given, exactly as execute would.
+      return __checkTyped(hit.entry, args === undefined ? {} : args, signature);
+    }
     const inputs = hit.entry.inputs || {};
     const provided = args && typeof args === 'object' ? args : {};
     const missing = [];
@@ -915,7 +1022,8 @@ const __actionsApi = {
       missing,
       unknown,
       typeErrors,
-      signature: __formatSignature(hit.plugin, hit.entry),
+      errors: [],
+      signature,
     };
   },
 };

--- a/packages/runline/src/tests/actions-api.test.ts
+++ b/packages/runline/src/tests/actions-api.test.ts
@@ -3,8 +3,10 @@ import { describe, it } from "node:test";
 import {
   Literal,
   Optional,
+  Array as TArray,
   Boolean as TBoolean,
   Object as TObject,
+  String as TString,
   Union,
 } from "typebox";
 import { DEFAULT_CONFIG } from "../config/types.js";
@@ -50,6 +52,26 @@ function makeGithub() {
       {
         mode: Union([Literal("safe"), Literal("loud")]),
         enabled: Optional(TBoolean()),
+      },
+      { additionalProperties: false },
+    ),
+    execute: async (input) => input,
+  });
+  // Mirrors the nested shape that exposed SHFT-1187 live
+  // (vex.sessions.remove): required fields and an additional-properties
+  // rule that exist only INSIDE the array items.
+  api.registerAction("collab.add", {
+    access: "write",
+    description: "Add collaborators",
+    inputSchema: TObject(
+      {
+        repo: TString(),
+        members: TArray(
+          TObject(
+            { externalId: TString(), label: Optional(TString()) },
+            { additionalProperties: false },
+          ),
+        ),
       },
       { additionalProperties: false },
     ),
@@ -101,6 +123,7 @@ describe("actions.list", () => {
     assert.deepEqual(
       [...result].sort(),
       [
+        "github.collab.add",
         "github.issue.create",
         "github.issue.list",
         "github.settings.update",
@@ -114,6 +137,7 @@ describe("actions.list", () => {
   it("filters by plugin prefix", async () => {
     const result = await run<string[]>('return actions.list("github")');
     assert.deepEqual([...result].sort(), [
+      "github.collab.add",
       "github.issue.create",
       "github.issue.list",
       "github.settings.update",
@@ -297,6 +321,86 @@ describe("actions.check", () => {
     ]);
   });
 
+  it("flags a nested array item missing its required field (SHFT-1187)", async () => {
+    // The live false positive: top-level fields all fine, the defect
+    // only inside members[0]. check must reject exactly what execute
+    // rejects, with the nested path named.
+    const result = await run<{
+      ok: boolean;
+      missing: string[];
+      unknown: string[];
+      errors: string[];
+    }>(
+      `return actions.check("github.collab.add", { repo: "r", members: [{ userId: "u1" }] })`,
+    );
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.missing, ["members[0].externalId"]);
+    assert.deepEqual(result.unknown, ["members[0].userId"]);
+    assert.ok(
+      result.errors.some((e) => e.includes("/members/0")),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("ok=true for a valid nested payload", async () => {
+    const result = await run<{ ok: boolean }>(
+      `return actions.check("github.collab.add", { repo: "r", members: [{ externalId: "e", label: "L" }] })`,
+    );
+    assert.equal(result.ok, true);
+  });
+
+  it("reports a nested type error under its nested path", async () => {
+    const result = await run<{
+      ok: boolean;
+      typeErrors: Array<{ field: string; expected: string; actual: string }>;
+    }>(
+      `return actions.check("github.collab.add", { repo: "r", members: [{ externalId: "e", label: 7 }] })`,
+    );
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.typeErrors, [
+      { field: "members[0].label", expected: "string", actual: "number" },
+    ]);
+  });
+
+  it("rejects a non-object input the way execution does", async () => {
+    const result = await run<{
+      ok: boolean;
+      typeErrors: Array<{ field: string; expected: string; actual: string }>;
+    }>(`return actions.check("github.settings.update", null)`);
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.typeErrors, [
+      { field: "(input)", expected: "object", actual: "null" },
+    ]);
+  });
+
+  it("check's verdict agrees with execution on typed schemas", async () => {
+    // The preflight's whole purpose: ok=false must predict the exact
+    // rejection, and ok=true must predict acceptance. Both sides run
+    // the same validator on the same schema, so this can only break
+    // if the schema stops travelling to the worker.
+    const result = await run<{
+      check: { ok: boolean; errors: string[] };
+      executed: string;
+    }>(`
+      const payload = { repo: "r", members: [{ userId: "u" }] };
+      const check = actions.check("github.collab.add", payload);
+      let executed = "ran";
+      try { await actions.github.collab.add(payload); } catch (e) { executed = e.message; }
+      return { check, executed };
+    `);
+    assert.equal(result.check.ok, false);
+    assert.match(
+      result.executed,
+      /\/members\/0 must have required properties externalId/,
+    );
+    for (const line of result.check.errors) {
+      assert.ok(
+        result.executed.includes(line),
+        `check error "${line}" missing from execution error "${result.executed}"`,
+      );
+    }
+  });
+
   it("returns suggestions for unknown action", async () => {
     const result = await run<{
       ok: boolean;
@@ -363,6 +467,6 @@ describe("actions proxy fallback", () => {
     const result = await run<unknown>(
       `const list = actions.list("github"); const r = await github.issue.list({ owner: "a", repo: "b" }); return { count: list.length, r };`,
     );
-    assert.deepEqual(result, { count: 4, r: [] });
+    assert.deepEqual(result, { count: 5, r: [] });
   });
 });


### PR DESCRIPTION
`actions.check` looped only over an action's top-level inputs, comparing each immediate type/enum/const. A payload whose defect lived one level down — an array item missing its required field, or carrying a forbidden one — came back `ok: true`, and the documented check-before-write workflow walked the agent straight into a rejected call. The flattened help metadata could never close the gap: it truncates deep nesting and carries no additional-properties rules.

Now the raw typed schema travels into the worker alongside the help data, and `check` runs the same typebox `Check`/`Errors` the host runs before execute — the preflight verdict and the execution verdict come from one validator on one schema and cannot diverge. TypeBox schemas are plain JSON, so they survive the stringify into the worker source; `typebox/value` is resolved host-side and required by absolute path, exactly like ferrosearch (bun and node ≥22.12).

The familiar `missing`/`unknown`/`typeErrors` buckets are derived from the validator's structured errors (keyword + params, never message parsing) with nested paths spelled `members[0].externalId`, grouping a failed union into one typeError instead of one per branch. A new `errors` array carries each raw `<path> <message>` line exactly as a rejected execution would report it; legacy flat schemas keep the existing field loop and gain the empty array for a uniform shape.

Two deliberate parity-driven semantics changes: stray keys under permissive `additionalProperties` now pass check (execute accepts them), and `check(path, null)` fails like execution instead of coercing to `{}`.

Five new tests, four seen red against the flat loop — including a parity test proving every check error line appears verbatim in the execution rejection for the same payload. Full suite 474 pass.